### PR TITLE
Add human-readable time strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,9 +340,11 @@ Functions can only be defined at the top level—not inside loops, conditionals,
 You can pause the execution of a sequence for a relative duration, or until an absolute time:
 ```py
 CdhCore.cmdDisp.CMD_NO_OP_STRING("second 0")
-# sleep for 1 second and 0 microseconds
-sleep(1, 0)
+# sleep for 1 second
+sleep(1)
 CdhCore.cmdDisp.CMD_NO_OP_STRING("second 1")
+# sleep for half a second
+sleep(useconds=500_000)
 
 
 CdhCore.cmdDisp.CMD_NO_OP_STRING("today")

--- a/README.md
+++ b/README.md
@@ -352,6 +352,19 @@ sleep_until(Fw.Time(0, 1, 1234567890, 0))
 CdhCore.cmdDisp.CMD_NO_OP_STRING("much later")
 ```
 
+You can also use the `time()` function to parse ISO 8601 timestamps:
+```py
+# Parse an ISO 8601 timestamp (UTC with Z suffix)
+sleep_until(time("2025-12-19T14:30:00Z"))
+
+# With microseconds
+t: Fw.Time = time("2025-12-19T14:30:00.123456Z")
+sleep_until(t)
+
+# Customize time_base and time_context (defaults are 0)
+t: Fw.Time = time("2025-12-19T14:30:00Z", time_base=2, time_context=1)
+```
+
 Make sure that the `Svc.FpySequencer.checkTimers` port is connected to a rate group. The sequencer only checks if a sleep is done when the port is called, so the more frequently you call it, the more accurate the wakeup time.
 
 ## 14. Exit Macro

--- a/src/fpy/SPEC.md
+++ b/src/fpy/SPEC.md
@@ -122,6 +122,7 @@ Available macros:
 * `sleep(seconds: U32, microseconds: U32)`: waits for the specified relative duration (the assembler emits `WaitRelDirective`).
 * `sleep_until(wakeup_time: Fw.Time)`: waits until the supplied absolute time using `WaitAbsDirective`.
 * `now() -> Fw.Time`: pushes the current time via `PushTimeDirective`.
+* `time(timestamp: String, time_base: U16 = 0, time_context: U8 = 0) -> Fw.Time`: parses an ISO 8601 timestamp string (e.g., `"2025-12-19T14:30:00Z"` or `"2025-12-19T14:30:00.123456Z"`) at compile time and returns an `Fw.Time` with the specified `time_base` and `time_context`. The timestamp must be in UTC with a `Z` suffix.
 * `iabs(value: I64) -> I64`: returns the absolute value of a signed 64-bit integer.
 * `fabs(value: F64) -> F64`: returns the absolute value of a 64-bit float.
 

--- a/src/fpy/SPEC.md
+++ b/src/fpy/SPEC.md
@@ -119,7 +119,7 @@ Available macros:
 
 * `exit(exit_code: U8)`: terminates the sequence immediately by emitting an `ExitDirective`.
 * `log(operand: F64) -> F64`: computes the natural logarithm of the operand using `FloatLogDirective` and leaves the `F64` result on the stack.
-* `sleep(seconds: U32, microseconds: U32)`: waits for the specified relative duration (the assembler emits `WaitRelDirective`).
+* `sleep(seconds: U32 = 0, microseconds: U32 = 0)`: waits for the specified relative duration (the assembler emits `WaitRelDirective`).
 * `sleep_until(wakeup_time: Fw.Time)`: waits until the supplied absolute time using `WaitAbsDirective`.
 * `now() -> Fw.Time`: pushes the current time via `PushTimeDirective`.
 * `time(timestamp: String, time_base: U16 = 0, time_context: U8 = 0) -> Fw.Time`: parses an ISO 8601 timestamp string (e.g., `"2025-12-19T14:30:00Z"` or `"2025-12-19T14:30:00.123456Z"`) at compile time and returns an `Fw.Time` with the specified `time_base` and `time_context`. The timestamp must be in UTC with a `Z` suffix.

--- a/src/fpy/desugaring.py
+++ b/src/fpy/desugaring.py
@@ -4,10 +4,11 @@ from fpy.syntax import (
     Ast,
     AstAssign,
     AstBinaryOp,
+    AstBoolean,
     AstFor,
     AstFuncCall,
-    AstTypeExpr,
     AstNumber,
+    AstTypeExpr,
     AstRange,
     AstVar,
     AstWhile,
@@ -22,6 +23,7 @@ from fpy.types import (
 )
 from fprime_gds.common.models.serialize.type_base import BaseType as FppValue
 from fprime_gds.common.models.serialize.bool_type import BoolType as BoolValue
+from fprime_gds.common.models.serialize.numerical_types import IntegerType as IntegerValue
 
 
 class DesugarForLoops(Transformer):
@@ -295,6 +297,7 @@ class DesugarDefaultArgs(Transformer):
     Desugars function calls with named or missing arguments by:
     1. Reordering named arguments to positional order
     2. Filling in default values for missing arguments
+    3. Converting FppValue defaults (from builtins) to AstNumber/AstBoolean nodes
 
     For example, if we have:
         def foo(a: U8, b: U8 = 5, c: U8 = 10):
@@ -310,6 +313,21 @@ class DesugarDefaultArgs(Transformer):
     value expressions.
     """
 
+    def _fpp_value_to_ast(self, value: FppValue, meta: Meta, state: CompileState) -> Ast:
+        """Convert an FppValue (from builtin default) to an AST literal node."""
+        if isinstance(value, BoolValue):
+            node = AstBoolean(meta=meta, value=value.val)
+        elif isinstance(value, IntegerValue):
+            node = AstNumber(meta=meta, value=value.val)
+        else:
+            assert False, f"Unsupported FppValue type for default arg: {type(value)}"
+
+        # Register the new node in state so codegen can find its type/value
+        state.synthesized_types[node] = type(value)
+        state.contextual_types[node] = type(value)
+        state.contextual_values[node] = value
+        return node
+
     def visit_AstFuncCall(self, node: AstFuncCall, state: CompileState):
         # Get the resolved arguments from semantic analysis.
         # This list is already in positional order with defaults filled in.
@@ -319,7 +337,15 @@ class DesugarDefaultArgs(Transformer):
             f"This should have been set by PickTypesAndResolveAttrsAndItems."
         )
 
-        # Update the node's args with the resolved arguments
-        node.args = resolved_args
+        # Convert any FppValue defaults to AST nodes
+        desugared_args = []
+        for arg in resolved_args:
+            if isinstance(arg, FppValue):
+                desugared_args.append(self._fpp_value_to_ast(arg, node.meta, state))
+            else:
+                desugared_args.append(arg)
+
+        # Update the node's args with the desugared arguments
+        node.args = desugared_args
 
         return node

--- a/src/fpy/desugaring.py
+++ b/src/fpy/desugaring.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from lark.tree import Meta
 from fpy.bytecode.directives import BinaryStackOp, Directive, LoopVarType
 from fpy.syntax import (
     Ast,

--- a/src/fpy/macros.py
+++ b/src/fpy/macros.py
@@ -9,10 +9,11 @@ from fpy.bytecode.directives import (
 )
 from fpy.ir import Ir, IrIf, IrLabel
 from fpy.syntax import Ast
-from fpy.types import BuiltinSymbol, NothingValue
+from fpy.types import BuiltinSymbol, FpyStringValue, NothingValue
 from fprime_gds.common.models.serialize.time_type import TimeType as TimeValue
 from fprime_gds.common.models.serialize.numerical_types import (
     U8Type as U8Value,
+    U16Type as U16Value,
     U32Type as U32Value,
     I64Type as I64Value,
     F64Type as F64Value,
@@ -99,9 +100,9 @@ MACRO_SLEEP_SECONDS_USECONDS = BuiltinSymbol(
         (
             "seconds",
             U32Value,
-            None,
+            U32Value(0),
         ),
-        ("microseconds", U32Value, None),
+        ("microseconds", U32Value, U32Value(0)),
     ],
     lambda n: [WaitRelDirective()],
 )
@@ -170,4 +171,16 @@ MACROS: dict[str, BuiltinSymbol] = {
     "now": BuiltinSymbol("now", TimeValue, [], lambda n: [PushTimeDirective()]),
     "iabs": MACRO_ABS_SIGNED_INT,
     "fabs": MACRO_ABS_FLOAT,
+    # time() parses ISO 8601 timestamps at compile time
+    # The generate function should never be called since this is always const-evaluated
+    "time": BuiltinSymbol(
+        "time",
+        TimeValue,
+        [
+            ("timestamp", FpyStringValue, None),
+            ("time_base", U16Value, U16Value(0)),
+            ("time_context", U8Value, U8Value(0)),
+        ],
+        lambda n: [],  # placeholder - const eval handles this
+    ),
 }

--- a/src/fpy/macros.py
+++ b/src/fpy/macros.py
@@ -102,7 +102,7 @@ MACRO_SLEEP_SECONDS_USECONDS = BuiltinSymbol(
             U32Value,
             U32Value(0),
         ),
-        ("microseconds", U32Value, U32Value(0)),
+        ("useconds", U32Value, U32Value(0)),
     ],
     lambda n: [WaitRelDirective()],
 )

--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from datetime import datetime, timezone
 from decimal import Decimal
 import decimal
 import struct
@@ -11,6 +12,7 @@ from fpy.types import (
     SIGNED_INTEGER_TYPES,
     SPECIFIC_NUMERIC_TYPES,
     UNSIGNED_INTEGER_TYPES,
+    BuiltinSymbol,
     CompileState,
     FieldSymbol,
     ForLoopAnalysis,
@@ -1340,10 +1342,11 @@ class PickTypesAndResolveAttrsAndItems(Visitor):
         for value_expr, arg in zip(resolved_args, func_args):
             arg_type = arg[1]
 
-            # Skip type check for default values from forward-called functions.
-            # These expressions haven't been visited yet, so they're not in
-            # synthesized_types. Their type compatibility is verified when
-            # the function definition is visited.
+            # Skip type check for default values that are FppValue instances (from builtins)
+            # or for default values from forward-called functions that haven't been visited yet.
+            if not is_instance_compat(value_expr, Ast):
+                # It's a raw FppValue default from a builtin - type is already correct
+                continue
             if value_expr not in state.synthesized_types:
                 continue
 
@@ -1399,8 +1402,10 @@ class PickTypesAndResolveAttrsAndItems(Visitor):
             state.expr_explicit_casts.append(node_arg)
         else:
             for value_expr, arg in zip(resolved_args, func.args):
-                # Skip coercion for default values from forward-called functions.
-                # These will be coerced when the function definition is visited.
+                # Skip coercion for FppValue defaults from builtins or
+                # for default values from forward-called functions.
+                if not is_instance_compat(value_expr, Ast):
+                    continue
                 if value_expr not in state.synthesized_types:
                     continue
                 arg_type = arg[1]
@@ -1552,6 +1557,60 @@ class CalculateConstExprValues(Visitor):
             return None
 
         return struct.unpack(fmt, packed)[0]
+
+    @staticmethod
+    def _parse_time_string(
+        time_str: str, time_base: int, time_context: int, node: Ast, state: CompileState
+    ) -> TimeValue | None:
+        """Parse an ISO 8601 timestamp string into a TimeValue.
+
+        Accepts formats like:
+        - "2025-12-19T14:30:00Z"
+        - "2025-12-19T14:30:00.123456Z"
+
+        Returns TimeValue with the provided time_base and time_context, and the parsed
+        seconds/microseconds since Unix epoch.
+        """
+        try:
+            # Try parsing with microseconds first
+            try:
+                dt = datetime.strptime(time_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+            except ValueError:
+                # Fall back to no microseconds
+                dt = datetime.strptime(time_str, "%Y-%m-%dT%H:%M:%SZ")
+
+            # Convert to UTC timestamp
+            dt = dt.replace(tzinfo=timezone.utc)
+            timestamp = dt.timestamp()
+
+            # Split into seconds and microseconds
+            seconds = int(timestamp)
+            useconds = int((timestamp - seconds) * 1_000_000)
+
+            # Validate ranges for U32
+            if seconds < 0:
+                state.err(
+                    f"Time string '{time_str}' results in negative seconds ({seconds}), "
+                    "which cannot be represented in Fw.Time",
+                    node,
+                )
+                return None
+            if seconds > 0xFFFFFFFF:
+                state.err(
+                    f"Time string '{time_str}' results in seconds ({seconds}) exceeding U32 max",
+                    node,
+                )
+                return None
+
+            return TimeValue(time_base=time_base, time_context=time_context, seconds=seconds, useconds=useconds)
+
+        except ValueError as e:
+            state.err(
+                f"Invalid time string '{time_str}': expected ISO 8601 format "
+                "(e.g., '2025-12-19T14:30:00Z' or '2025-12-19T14:30:00.123456Z')",
+                node,
+            )
+            return None
 
     @staticmethod
     def const_convert_type(
@@ -1837,10 +1896,15 @@ class CalculateConstExprValues(Visitor):
         resolved_args = state.resolved_func_args[node]
 
         # Gather arg values. Since defaults are already filled in, we just need
-        # to look up each arg's const value.
-        arg_values = [
-            state.contextual_values.get(arg_expr) for arg_expr in resolved_args
-        ]
+        # to look up each arg's const value. For FppValue defaults from builtins,
+        # use the value directly.
+        arg_values = []
+        for arg_expr in resolved_args:
+            if is_instance_compat(arg_expr, Ast):
+                arg_values.append(state.contextual_values.get(arg_expr))
+            else:
+                # It's a raw FppValue default from a builtin
+                arg_values.append(arg_expr)
 
         unknown_value = any(v is None for v in arg_values)
         if unknown_value:
@@ -1876,6 +1940,16 @@ class CalculateConstExprValues(Visitor):
             # should only be one value. it should be of some numeric type
             # our const convert type func will convert it for us
             expr_value = arg_values[0]
+        elif is_instance_compat(func, BuiltinSymbol) and func.name == "time":
+            # time() builtin parses ISO 8601 timestamps at compile time
+            timestamp_str = arg_values[0].val
+            time_base = arg_values[1].val
+            time_context = arg_values[2].val
+            expr_value = self._parse_time_string(
+                timestamp_str, time_base, time_context, node, state
+            )
+            if expr_value is None:
+                return
         else:
             # don't try to calculate the value of this function call
             # it's something like a user defined func, cmd or builtin

--- a/test/fpy/test_seqs.py
+++ b/test/fpy/test_seqs.py
@@ -462,6 +462,16 @@ sleep(1, 1000)
     assert_run_success(fprime_test_api, seq)
 
 
+def test_wait_rel_default_args(fprime_test_api):
+    seq = """
+sleep()
+sleep(5)
+sleep(seconds=3)
+sleep(microseconds=500)
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
 def test_wait_abs(fprime_test_api):
     seq = """
 sleep_until(Fw.Time(2, 0, 123, 123))
@@ -3620,3 +3630,118 @@ assert test(c=x, a=y, b=z) == 5.5
 """
 
     assert_run_success(fprime_test_api, seq)
+
+
+# ==================== Time Function Tests ====================
+
+
+def test_time_function_basic(fprime_test_api):
+    """time() parses ISO 8601 strings to Fw.Time."""
+    seq = """
+t: Fw.Time = time("2000-01-01T00:00:00Z")
+# Unix timestamp for 2000-01-01T00:00:00Z is 946684800
+assert t.seconds == 946684800
+assert t.useconds == 0
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
+def test_time_function_with_microseconds(fprime_test_api):
+    """time() parses ISO 8601 strings with microseconds."""
+    seq = """
+t: Fw.Time = time("2000-01-01T00:00:00.123456Z")
+assert t.seconds == 946684800
+assert t.useconds == 123456
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
+def test_time_function_sleep_until(fprime_test_api):
+    """time() can be passed directly to sleep_until()."""
+    seq = """
+sleep_until(time("2000-01-01T00:00:00Z"))
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
+def test_time_function_invalid_format(fprime_test_api):
+    """Invalid time string format should fail at compile time."""
+    seq = """
+t: Fw.Time = time("not a valid time")
+"""
+    assert_compile_failure(fprime_test_api, seq)
+
+
+def test_time_function_invalid_format_2(fprime_test_api):
+    """Time string without Z suffix should fail."""
+    seq = """
+t: Fw.Time = time("2000-01-01T00:00:00")
+"""
+    assert_compile_failure(fprime_test_api, seq)
+
+
+def test_time_function_default_time_base(fprime_test_api):
+    """time() defaults to time_base=0 and time_context=0."""
+    seq = """
+t: Fw.Time = time("2000-01-01T00:00:00Z")
+assert t.time_base == 0
+assert t.time_context == 0
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
+def test_time_function_custom_time_base(fprime_test_api):
+    """time() accepts custom time_base parameter."""
+    seq = """
+t: Fw.Time = time("2000-01-01T00:00:00Z", time_base=2)
+assert t.time_base == 2
+assert t.time_context == 0
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
+def test_time_function_custom_time_context(fprime_test_api):
+    """time() accepts custom time_context parameter."""
+    seq = """
+t: Fw.Time = time("2000-01-01T00:00:00Z", time_context=5)
+assert t.time_base == 0
+assert t.time_context == 5
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
+def test_time_function_all_params(fprime_test_api):
+    """time() accepts all parameters."""
+    seq = """
+t: Fw.Time = time("2000-01-01T00:00:00Z", time_base=3, time_context=7)
+assert t.time_base == 3
+assert t.time_context == 7
+assert t.seconds == 946684800
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
+def test_time_function_named_args(fprime_test_api):
+    """time() works with named arguments."""
+    seq = """
+t: Fw.Time = time(timestamp="2000-01-01T00:00:00Z", time_base=1)
+assert t.time_base == 1
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
+def test_time_function_negative_seconds(fprime_test_api):
+    """Time before Unix epoch (1970) should fail with negative seconds error."""
+    seq = """
+t: Fw.Time = time("1969-01-01T00:00:00Z")
+"""
+    assert_compile_failure(fprime_test_api, seq)
+
+
+def test_time_function_u32_overflow(fprime_test_api):
+    """Time after year 2106 overflows U32 seconds."""
+    # U32 max is 4,294,967,295 seconds after 1970 = year ~2106
+    seq = """
+t: Fw.Time = time("2200-01-01T00:00:00Z")
+"""
+    assert_compile_failure(fprime_test_api, seq)

--- a/test/fpy/test_seqs.py
+++ b/test/fpy/test_seqs.py
@@ -467,7 +467,7 @@ def test_wait_rel_default_args(fprime_test_api):
 sleep()
 sleep(5)
 sleep(seconds=3)
-sleep(microseconds=500)
+sleep(useconds=500)
 """
     assert_run_success(fprime_test_api, seq)
 
@@ -1516,6 +1516,12 @@ uint: U32 = 123123
 int: I32 = I32(uint)
 assert int == 123123
 
+CdhCore.cmdDisp.CMD_NO_OP_STRING("second 0")
+# sleep for 1 second
+sleep(1)
+CdhCore.cmdDisp.CMD_NO_OP_STRING("second 1")
+# sleep for half a second
+sleep(useconds=500_000)
 
 value: bool = 1 > 2 and (3 + 4) != 5
 many_cmds_dispatched: bool = cmds_dispatched >= 123
@@ -3548,7 +3554,7 @@ assert pair.secondChoice == Ref.Choice.TWO
 def test_named_arg_builtin(fprime_test_api):
     """Named arguments work with builtin functions."""
     seq = """
-sleep(microseconds=1000, seconds=1)
+sleep(useconds=1000, seconds=1)
 """
 
     assert_run_success(fprime_test_api, seq)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#4590 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

* Adds the `time` function, which takes an ISO 8601 string and an optional time base and context (default to 0), and returns a Fw.Time object. Runs at compile time
* Adds default values of 0, 0 for the `sleep` function, so you don't always have to specify us if you specify sec
## Rationale

* Makes times much more human readable and easy to use
