### PR TITLE
Better version numbers in help msg

### DIFF
--- a/src/fpy/main.py
+++ b/src/fpy/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from importlib.metadata import version
 from pathlib import Path
 import sys
 
@@ -33,13 +34,23 @@ def human_readable_size(size_bytes):
     return f"{size_bytes} {units[unit_idx]}"
 
 
+def get_package_version() -> str:
+    try:
+        return version("fprime-fpy")
+    except Exception:
+        return "unknown"
+
+
 def get_version_str() -> str:
-    return f"Version {MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION} schema {SCHEMA_VERSION}"
+    return f"package {get_package_version()} langauge {MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION} schema {SCHEMA_VERSION}"
 
 
 def compile_main(args: list[str] = None):
     arg_parser = argparse.ArgumentParser(
-        description=f"Fpy compiler. {get_version_str()}"
+        description=f"Fpy compiler {get_version_str()}"
+    )
+    arg_parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {get_version_str()}"
     )
     arg_parser.add_argument("input", type=Path, help="The input .fpy file")
     arg_parser.add_argument(
@@ -116,7 +127,10 @@ def compile_main(args: list[str] = None):
 
 
 def model_main(args: list[str] = None):
-    arg_parser = argparse.ArgumentParser(description=f"FpySequencer model for testing. {get_version_str()}")
+    arg_parser = argparse.ArgumentParser(description=f"FpySequencer model for testing {get_version_str()}")
+    arg_parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {get_version_str()}"
+    )
     arg_parser.add_argument("input", type=Path, help="The input .bin file")
     arg_parser.add_argument(
         "--debug",
@@ -145,7 +159,10 @@ def model_main(args: list[str] = None):
 
 
 def assemble_main(args: list[str] = None):
-    arg_parser = argparse.ArgumentParser(description=f"Fpy assembler. {get_version_str()}")
+    arg_parser = argparse.ArgumentParser(description=f"Fpy assembler {get_version_str()}")
+    arg_parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {get_version_str()}"
+    )
     arg_parser.add_argument("input", type=Path, help="The input .fpybc file")
     arg_parser.add_argument(
         "-o",
@@ -176,7 +193,10 @@ def assemble_main(args: list[str] = None):
 
 
 def disassemble_main(args: list[str] = None):
-    arg_parser = argparse.ArgumentParser(description=f"Fpy disassembler. {get_version_str()}")
+    arg_parser = argparse.ArgumentParser(description=f"Fpy disassembler {get_version_str()}")
+    arg_parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {get_version_str()}"
+    )
     arg_parser.add_argument("input", type=Path, help="The input .bin file")
     arg_parser.add_argument(
         "-o",

--- a/src/fpy/types.py
+++ b/src/fpy/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from abc import ABC
 from decimal import Decimal
+from importlib.metadata import version
 import inspect
 from dataclasses import astuple, dataclass, field, fields
 import math
@@ -795,9 +796,21 @@ class Emitter:
         return self.emitters[type(node)](node, state)
 
 
-MAJOR_VERSION = 0
-MINOR_VERSION = 3
-PATCH_VERSION = 0
+def _get_version_tuple() -> tuple[int, int, int]:
+    try:
+        import re
+        v = version("fprime-fpy")
+        # Handle versions like "0.0.1a3.dev103+g244fdeadc"
+        # Extract just the major.minor.patch part
+        match = re.match(r"(\d+)\.(\d+)\.(\d+)", v)
+        if match:
+            return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        return (0, 0, 0)
+    except Exception:
+        return (0, 0, 0)
+
+
+MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION = _get_version_tuple()
 SCHEMA_VERSION = 4
 
 HEADER_FORMAT = "!BBBBBHI"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description
Add semantic version string in help
Also make the binary header use the semantic version from package tag
