### PR TITLE
Add Arguments Placeholder to Sequences

### DIFF
--- a/src/fpy/codegen.py
+++ b/src/fpy/codegen.py
@@ -927,6 +927,12 @@ class GenerateFunctionBody(Emitter):
         return dirs
 
     def emit_AstAssign(self, node: AstAssign, state: CompileState):
+        # Handle arg declarations without initialization (rhs is None)
+        if node.rhs is None:
+            # This is an arg parameter declaration without initialization
+            # Space is already allocated in AssignVariableOffsets, no code generation needed
+            return []
+
         lhs = state.resolved_symbols[node.lhs]
 
         const_frame_offset = -1

--- a/src/fpy/compiler.py
+++ b/src/fpy/compiler.py
@@ -21,6 +21,7 @@ from fpy.semantics import (
     CreateScopes,
     CalculateConstExprValues,
     CalculateDefaultArgConstValues,
+    CheckArgDeclarationsAtTop,
     CheckBreakAndContinueInLoop,
     CheckConstArrayAccesses,
     CheckFunctionReturns,
@@ -482,6 +483,8 @@ def ast_to_directives(
         # Function bodies are deferred so that globals declared later in
         # the source are visible inside functions.
         CreateVariablesAndFuncs(),
+        # check that 'arg' declarations only appear at the top of the sequence
+        CheckArgDeclarationsAtTop(),
         # check that break/continue are in loops, and store which loop they're in
         CheckBreakAndContinueInLoop(),
         CheckReturnInFunc(),

--- a/src/fpy/desugaring.py
+++ b/src/fpy/desugaring.py
@@ -83,7 +83,7 @@ class DesugarForLoops(Transformer):
         rhs = loop_node.range.lower_bound
         return self.new(
             state,
-            AstAssign(None, lhs, loop_var_type_var, rhs),
+            AstAssign(None, None, lhs, loop_var_type_var, rhs),
             contextual_type=None,
             synthesized_type=None,
             contextual_value=None,
@@ -126,7 +126,7 @@ class DesugarForLoops(Transformer):
         return self.new(
             state,
             AstAssign(
-                None, upper_bound_var, loop_var_type_var, loop_node.range.upper_bound
+                None, None, upper_bound_var, loop_var_type_var, loop_node.range.upper_bound
             ),
             contextual_type=None,
             synthesized_type=None,
@@ -191,7 +191,7 @@ class DesugarForLoops(Transformer):
 
         return self.new(
             state,
-            AstAssign(None, lhs, None, rhs),
+            AstAssign(None, None, lhs, None, rhs),
             contextual_type=None,
             synthesized_type=None,
             contextual_value=None,

--- a/src/fpy/desugaring.py
+++ b/src/fpy/desugaring.py
@@ -432,7 +432,7 @@ class DesugarCheckStatements(Transformer):
         return AstUnaryOp(self.meta, op, val)
     
     def assign(self, lhs, rhs, type_ann=None) -> AstAssign:
-        return AstAssign(self.meta, lhs, type_ann, rhs)
+        return AstAssign(self.meta, None, lhs, type_ann, rhs)
     
     def if_stmt(self, cond, body_stmts, else_stmts=None) -> AstIf:
         body = AstBlock(self.meta, list(body_stmts))

--- a/src/fpy/grammar.lark
+++ b/src/fpy/grammar.lark
@@ -34,6 +34,9 @@ return_stmt: "return" [expr]
 assign_stmt: expr [":" expr] "=" expr
 # -> AstAssign(lhs, type_ann, rhs)
 
+var_tag: "arg"
+assign: [var_tag] expr [":" type_expr] "=" expr
+
 
 # the function definition statement
 # functions may be defined with zero or more comma-separated parameters, and an

--- a/src/fpy/grammar.lark
+++ b/src/fpy/grammar.lark
@@ -33,12 +33,8 @@ return_stmt: "return" [expr]
 # -> AstReturn(value)
 assign_stmt: expr [":" expr] "=" expr
 # -> AstAssign(None, lhs, type_ann, rhs)
-arg_stmnt: "arg" expr ":" type_expr ["=" expr]
+arg_stmnt: "arg" expr ":" expr ["=" expr]
 # -> AstAssign("arg", lhs, type_ann, rhs)
-
-arg_decl: 
-assign: expr [":" type_expr] "=" expr
-
 
 # the function definition statement
 # functions may be defined with zero or more comma-separated parameters, and an

--- a/src/fpy/grammar.lark
+++ b/src/fpy/grammar.lark
@@ -11,7 +11,7 @@ _toplevel_stmt: def_stmt | _stmt
 # Small statements must be followed by a newline; compound statements end with their block's DEDENT
 _stmt: _small_stmt _NEWLINE | _compound_stmt
 # small statements are those which cannot themselves contain statements
-_small_stmt: expr_stmt | assign_stmt | pass_stmt | break_stmt | continue_stmt | assert_stmt | return_stmt
+_small_stmt: expr_stmt | assign_stmt | arg_stmnt | pass_stmt | break_stmt | continue_stmt | assert_stmt | return_stmt
 # compound statements may contain other statements
 _compound_stmt: if_stmt | for_stmt | while_stmt | check_stmt
 
@@ -32,10 +32,12 @@ assert_stmt: "assert" expr ["," expr]
 return_stmt: "return" [expr]
 # -> AstReturn(value)
 assign_stmt: expr [":" expr] "=" expr
-# -> AstAssign(lhs, type_ann, rhs)
+# -> AstAssign(None, lhs, type_ann, rhs)
+arg_stmnt: "arg" expr ":" type_expr ["=" expr]
+# -> AstAssign("arg", lhs, type_ann, rhs)
 
-var_tag: "arg"
-assign: [var_tag] expr [":" type_expr] "=" expr
+arg_decl: 
+assign: expr [":" type_expr] "=" expr
 
 
 # the function definition statement

--- a/src/fpy/grammar.lark
+++ b/src/fpy/grammar.lark
@@ -11,7 +11,7 @@ _toplevel_stmt: def_stmt | _stmt
 # Small statements must be followed by a newline; compound statements end with their block's DEDENT
 _stmt: _small_stmt _NEWLINE | _compound_stmt
 # small statements are those which cannot themselves contain statements
-_small_stmt: expr_stmt | assign_stmt | arg_stmnt | pass_stmt | break_stmt | continue_stmt | assert_stmt | return_stmt
+_small_stmt: expr_stmt | assign_stmt | arg_stmt | pass_stmt | break_stmt | continue_stmt | assert_stmt | return_stmt
 # compound statements may contain other statements
 _compound_stmt: if_stmt | for_stmt | while_stmt | check_stmt
 
@@ -33,7 +33,7 @@ return_stmt: "return" [expr]
 # -> AstReturn(value)
 assign_stmt: expr [":" expr] "=" expr
 # -> AstAssign(None, lhs, type_ann, rhs)
-arg_stmnt: "arg" expr ":" expr ["=" expr]
+arg_stmt: "arg" expr ":" expr ["=" expr]
 # -> AstAssign("arg", lhs, type_ann, rhs)
 
 # the function definition statement

--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -274,7 +274,18 @@ class CreateVariablesAndFuncs(TopDownVisitor):
 
         if node.type_ann is not None:
             # new variable declaration
-            # make sure it isn't defined in this scope (shadowing parent scopes is ok)
+            # Validate initialization requirements
+            if node.tag != "arg" and node.rhs is None:
+                # Non-arg declarations must have an initialization value
+                state.err(
+                    "Variable declaration must have an initialization value. "
+                    "Only 'arg' declarations can omit initialization.",
+                    node
+                )
+                return
+
+            # make sure it isn't defined in this scope
+            # TODO shadowing check
             existing_local = scope.get(node.lhs.name)
             if existing_local is not None:
                 # redeclaring an existing variable in the SAME scope
@@ -288,8 +299,12 @@ class CreateVariablesAndFuncs(TopDownVisitor):
             # new var. put it in the scope
             scope[node.lhs.name] = var
         else:
-            # otherwise, it's a reference to an existing var
-            # walk up the scope chain to find it
+            # otherwise, it's a reference to an existing var (reassignment)
+            if node.rhs is None:
+                # Assignment without value doesn't make sense
+                state.err("Assignment must have a value", node)
+                return
+
             sym = scope.lookup(node.lhs.name)
             if sym is None:
                 # unable to find this symbol
@@ -805,8 +820,10 @@ class CheckUseBeforeDefine(TopDownVisitor):
             # declaration of this var
             return
 
-        # Before marking as defined, check that the variable isn't used in its own RHS
-        EnsureVariableNotReferenced(var).run(node.rhs, state)
+        # Before marking as declared, check that the variable isn't used in its own RHS
+        # (Only if rhs exists - arg declarations without init have rhs=None)
+        if node.rhs is not None:
+            EnsureVariableNotReferenced(var).run(node.rhs, state)
 
         # Now mark this variable as defined
         self.currently_defined_vars.append(var)
@@ -1750,8 +1767,10 @@ class PickTypesAndResolveFields(Visitor):
             lhs_type = state.contextual_types[node.lhs]
 
         # coerce the rhs into the lhs type
-        if not self.coerce_expr_type(node.rhs, lhs_type, state):
-            return
+        # (Only if rhs exists - arg declarations without init have rhs=None)
+        if node.rhs is not None:
+            if not self.coerce_expr_type(node.rhs, lhs_type, state):
+                return
 
     def visit_AstAssert(self, node: AstAssert, state: CompileState):
         if not self.coerce_expr_type(node.condition, BOOL, state):

--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -654,6 +654,53 @@ def is_type_constant_size(type: FpyType) -> bool:
         return True
 
     return True
+class CheckArgDeclarationsAtTop(TopDownVisitor):
+    """
+    Ensures that 'arg' tagged variables only appear at the very top of the main sequence.
+    Once we see any non-arg statement, all subsequent arg declarations are errors.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.seen_non_arg_statement = False
+        self.first_non_arg_location = None
+
+    def visit_AstBlock(self, node: AstBlock, state: CompileState):
+        # Only check the root block (top-level sequence)
+        if node is not state.root:
+            return
+
+        # Walk through statements in order
+        for stmt in node.stmts:
+            self._check_statement(stmt, state)
+
+    def _check_statement(self, stmt: AstStmt, state: CompileState):
+        """Check a single statement."""
+        if isinstance(stmt, AstAssign):
+            # Check if this is an arg declaration
+            tag = stmt.tag
+
+            if tag == "arg":
+                # This is an arg declaration
+                if self.seen_non_arg_statement:
+                    # Error: arg after non-arg statement
+                    state.err(
+                        f"'arg' declarations must appear at the top of the sequence.\n"
+                        f"First non-arg statement was at line {self.first_non_arg_location.line}",
+                        stmt
+                    )
+            else:
+                # This is not an arg declaration (either no tag or different tag)
+                if not self.seen_non_arg_statement:
+                    self.seen_non_arg_statement = True
+                    self.first_non_arg_location = stmt.meta
+        else:
+            # Any non-assignment statement (commands, if, while, def, etc.)
+            if not self.seen_non_arg_statement:
+                self.seen_non_arg_statement = True
+                self.first_non_arg_location = stmt.meta
+
+
 
 
 class UpdateTypesAndFuncs(Visitor):

--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -673,12 +673,15 @@ class CheckArgDeclarationsAtTop(TopDownVisitor):
     """
     Ensures that 'arg' tagged variables only appear at the very top of the main sequence.
     Once we see any non-arg statement, all subsequent arg declarations are errors.
+
+    Builtin function definitions (prepended by the compiler) are skipped, but user-defined
+    functions count as non-arg statements.
     """
 
     def __init__(self):
         super().__init__()
         self.seen_non_arg_statement = False
-        self.first_non_arg_location = None
+        self.seen_user_code = False  # Track when we transition from builtins to user code
 
     def visit_AstBlock(self, node: AstBlock, state: CompileState):
         # Only check the root block (top-level sequence)
@@ -690,30 +693,31 @@ class CheckArgDeclarationsAtTop(TopDownVisitor):
             self._check_statement(stmt, state)
 
     def _check_statement(self, stmt: AstStmt, state: CompileState):
-        """Check a single statement."""
+        # Function definitions: skip builtin functions (before any user code),
+        # but treat user-defined functions as non-arg statements
+        if isinstance(stmt, AstDef):
+            if not self.seen_user_code:
+                # Still in builtin function territory, skip it
+                return
+            # This is a user-defined function, treat as non-arg statement
+            self.seen_non_arg_statement = True
+            return
+
+        # Any non-function statement marks the start of user code
+        self.seen_user_code = True
+
         if isinstance(stmt, AstAssign):
             # Check if this is an arg declaration
-            tag = stmt.tag
-
-            if tag == "arg":
+            if stmt.tag == "arg":
                 # This is an arg declaration
                 if self.seen_non_arg_statement:
                     # Error: arg after non-arg statement
                     state.err(
-                        f"'arg' declarations must appear at the top of the sequence.\n"
-                        f"First non-arg statement was at line {self.first_non_arg_location.line}",
+                        f"'arg' declarations must appear at the top of the sequence.\n",
                         stmt
                     )
-            else:
-                # This is not an arg declaration (either no tag or different tag)
-                if not self.seen_non_arg_statement:
-                    self.seen_non_arg_statement = True
-                    self.first_non_arg_location = stmt.meta
-        else:
-            # Any non-assignment statement (commands, if, while, def, etc.)
-            if not self.seen_non_arg_statement:
-                self.seen_non_arg_statement = True
-                self.first_non_arg_location = stmt.meta
+                return
+        self.seen_non_arg_statement = True
 
 
 

--- a/src/fpy/syntax.py
+++ b/src/fpy/syntax.py
@@ -249,6 +249,7 @@ AstExpr = Union[AstFuncCall, AstLiteral, AstReference, AstOp, AstRange, AstAnonS
 
 @dataclass
 class AstAssign(Ast):
+    tag: str | None
     lhs: AstExpr
     type_ann: AstExpr | None
     rhs: AstExpr
@@ -492,6 +493,10 @@ class FpyTransformer(Transformer):
     pass_stmt = AstPass
 
     assign_stmt = AstAssign
+
+    def var_tag(self, meta):
+        # The var_tag rule matches "arg" literal
+        return "arg"
 
     for_stmt = AstFor
     while_stmt = AstWhile

--- a/src/fpy/syntax.py
+++ b/src/fpy/syntax.py
@@ -498,7 +498,7 @@ class FpyTransformer(Transformer):
         return AstAssign(meta, None, lhs, type_ann, rhs)
 
     @v_args(meta=True, inline=True)
-    def arg_stmnt(self, meta, lhs, type_ann, rhs=None):
+    def arg_stmt(self, meta, lhs, type_ann, rhs=None):
         # arg declaration: arg x: U8 [= value]
         # rhs is optional and defaults to None if not provided
         return AstAssign(meta, "arg", lhs, type_ann, rhs)

--- a/src/fpy/syntax.py
+++ b/src/fpy/syntax.py
@@ -252,7 +252,7 @@ class AstAssign(Ast):
     tag: str | None
     lhs: AstExpr
     type_ann: AstExpr | None
-    rhs: AstExpr
+    rhs: AstExpr | None
 
 
 @dataclass
@@ -492,11 +492,16 @@ class FpyTransformer(Transformer):
     input = no_inline(AstBlock)
     pass_stmt = AstPass
 
-    assign_stmt = AstAssign
+    @v_args(meta=True, inline=True)
+    def assign_stmt(self, meta, lhs, type_ann, rhs):
+        # Regular assignment (no tag): x: U8 = value or x = value
+        return AstAssign(meta, None, lhs, type_ann, rhs)
 
-    def var_tag(self, meta):
-        # The var_tag rule matches "arg" literal
-        return "arg"
+    @v_args(meta=True, inline=True)
+    def arg_stmnt(self, meta, lhs, type_ann, rhs=None):
+        # arg declaration: arg x: U8 [= value]
+        # rhs is optional and defaults to None if not provided
+        return AstAssign(meta, "arg", lhs, type_ann, rhs)
 
     for_stmt = AstFor
     while_stmt = AstWhile

--- a/test/fpy/test_seqs.py
+++ b/test/fpy/test_seqs.py
@@ -4645,9 +4645,9 @@ assert counter >= 2
 
 def test_func_modify_param(fprime_test_api):
     seq = """
-def test(arg: U8):
-    arg = 1
-    assert arg == 1
+def test($arg: U8):
+    $arg = 1
+    assert $arg == 1
 
 val: U8 = 123
 test(val)

--- a/test/fpy/test_seqs.py
+++ b/test/fpy/test_seqs.py
@@ -5060,6 +5060,8 @@ def test_set_flag_basic(fprime_test_api):
 set_flag(Svc.Fpy.FlagId.EXIT_ON_CMD_FAIL, True)
 """
     assert_run_success(fprime_test_api, seq)
+
+
 def test_arg_valid(fprime_test_api):
     """Test that arg declarations at the top of a sequence work correctly."""
     seq = """
@@ -5792,6 +5794,8 @@ assert (
 )
 """
         assert_run_success(fprime_test_api, seq)
+
+
 def test_arg_invalid_after_command(fprime_test_api):
     """Test that arg declarations after commands fail to compile."""
     seq = """

--- a/test/fpy/test_seqs.py
+++ b/test/fpy/test_seqs.py
@@ -5060,6 +5060,19 @@ def test_set_flag_basic(fprime_test_api):
 set_flag(Svc.Fpy.FlagId.EXIT_ON_CMD_FAIL, True)
 """
     assert_run_success(fprime_test_api, seq)
+def test_arg_valid(fprime_test_api):
+    """Test that arg declarations at the top of a sequence work correctly."""
+    seq = """
+# All arg declarations must be at the top
+arg input_param: U8 = 0
+arg threshold: F32 = 1.5
+arg enable_feature: bool = True
+
+# Now regular code can begin
+result: U32 = 42
+counter: U8 = input_param
+"""
+    assert_run_success(fprime_test_api, seq)
 
 
 def test_set_flag_false(fprime_test_api):
@@ -5114,6 +5127,18 @@ def test_set_flag_wrong_type(fprime_test_api):
     """set_flag with an integer instead of FlagId should fail compilation."""
     seq = """
 set_flag(0, True)
+"""
+    assert_compile_failure(fprime_test_api, seq)
+def test_arg_invalid_after_statement(fprime_test_api):
+    """Test that arg declarations after non-arg statements fail to compile."""
+    seq = """
+arg param1: U8 = 0
+
+# This non-arg statement breaks the rule
+regular_var: U32 = 42
+
+# This should cause a compile error
+arg param2: U16 = 100
 """
     assert_compile_failure(fprime_test_api, seq)
 
@@ -5753,3 +5778,30 @@ assert (
 )
 """
         assert_run_success(fprime_test_api, seq)
+def test_arg_invalid_after_command(fprime_test_api):
+    """Test that arg declarations after commands fail to compile."""
+    seq = """
+arg param1: U8 = 0
+
+# Command breaks the arg-only section
+CdhCore.cmdDisp.CMD_NO_OP()
+
+# This should fail
+arg param2: U16 = 100
+"""
+    assert_compile_failure(fprime_test_api, seq)
+
+
+def test_arg_invalid_after_function(fprime_test_api):
+    """Test that arg declarations after function definitions fail to compile."""
+    seq = """
+arg param1: U8 = 0
+
+# Function definition breaks the arg-only section
+def my_func():
+    CdhCore.cmdDisp.CMD_NO_OP()
+
+# This should fail
+arg param2: U16 = 100
+"""
+    assert_compile_failure(fprime_test_api, seq)

--- a/test/fpy/test_seqs.py
+++ b/test/fpy/test_seqs.py
@@ -5081,6 +5081,18 @@ def test_set_flag_false(fprime_test_api):
 set_flag(Svc.Fpy.FlagId.EXIT_ON_CMD_FAIL, False)
 """
     assert_run_success(fprime_test_api, seq)
+def test_arg_without_initialization(fprime_test_api):
+    """Test that arg declarations work without initialization values."""
+    seq = """
+# Args without initialization - values provided by caller
+arg param1: U8
+arg param2: F32
+arg param3: bool
+
+# Args can be used in expressions
+result: U8 = param1
+"""
+    assert_run_success(fprime_test_api, seq)
 
 
 def test_set_and_get_flag(fprime_test_api):
@@ -5129,6 +5141,8 @@ def test_set_flag_wrong_type(fprime_test_api):
 set_flag(0, True)
 """
     assert_compile_failure(fprime_test_api, seq)
+
+
 def test_arg_invalid_after_statement(fprime_test_api):
     """Test that arg declarations after non-arg statements fail to compile."""
     seq = """

--- a/test/fpy/test_types_visitors.py
+++ b/test/fpy/test_types_visitors.py
@@ -70,7 +70,7 @@ def test_visitor_depth_first_traversal():
 
     lhs = AstIdent(meta=None, name="x")
     rhs = AstNumber(meta=None, value=7)
-    assign = AstAssign(meta=None, lhs=lhs, type_ann=None, rhs=rhs)
+    assign = AstAssign(meta=None, tag=None, lhs=lhs, type_ann=None, rhs=rhs)
 
     visitor.run(assign, state)
 
@@ -96,7 +96,7 @@ def test_top_down_visitor_breadth_first_order():
 
     lhs = AstIdent(meta=None, name="x")
     rhs = AstNumber(meta=None, value=5)
-    assign = AstAssign(meta=None, lhs=lhs, type_ann=None, rhs=rhs)
+    assign = AstAssign(meta=None, tag=None, lhs=lhs, type_ann=None, rhs=rhs)
 
     visitor.run(assign, state)
 
@@ -140,7 +140,7 @@ def test_visitor_stops_on_error():
 
     lhs = AstIdent(meta=None, name="x")
     rhs = AstNumber(meta=None, value=9)
-    assign = AstAssign(meta=None, lhs=lhs, type_ann=None, rhs=rhs)
+    assign = AstAssign(meta=None, tag=None, lhs=lhs, type_ann=None, rhs=rhs)
 
     visitor.run(assign, state)
 
@@ -172,7 +172,7 @@ def test_transformer_replaces_child_nodes():
 
     lhs = AstIdent(meta=None, name="answer")
     rhs = AstNumber(meta=None, value=42)
-    assign = AstAssign(meta=None, lhs=lhs, type_ann=None, rhs=rhs)
+    assign = AstAssign(meta=None, tag=None, lhs=lhs, type_ann=None, rhs=rhs)
 
     transformer.run(assign, state)
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [fprime#4662](https://github.com/nasa/fprime/issues/4662) [fprime#4181](https://github.com/nasa/fprime/issues/4181) |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Preliminary sequence argument addition to Fpy sequences

## Rationale

As per customer request, Fpy sequences need support for in-place arguments that may be called from other Fpy sequences. This is the first step towards creating a specific "arg" keyword for use in Fpy sequences

## Testing/Review Recommendations

Run pytest

## Future Work

* Need replacement of arguments with actual values called from other sequences
* Figure out call syntax for sequences with arguments
* Ensure drop-in replacement of arguments to sequence arguments