### PR TITLE
Allow blank issues in Github

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Open an Issue with F´
-    url: https://github.com/nasa/fprime/issues/new/choose
-    about: Issues about this repository are centrally managed in the core F´ repository
-  - name: F´ Community Discussions
-    url: https://github.com/nasa/fprime/discussions
-    about: Questions should be asked in the F´ Discussions
+blank_issues_enabled: true


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Allows blank issues to be made in the Fpy github, so we can separate the issues from Fprime
