### PR TITLE
Rename check `freq` to `period`, allow body-less check

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,8 +469,7 @@ CdhCore.cmdDisp.CMD_NO_OP_STRING("checkTimers called!")
 
 CdhCore.cmdDisp.CMD_NO_OP_STRING("today")
 # sleep until 1234567890 seconds and 0 microseconds after the epoch
-# time base of 0, time context of 1
-sleep_until({timeBase: 0, timeContext: 1, seconds=1234567890, useconds=0})
+sleep_until({timeBase: TimeBase.TB_NONE, timeContext: 1, seconds: 1234567890, useconds: 0})
 CdhCore.cmdDisp.CMD_NO_OP_STRING("much later")
 ```
 
@@ -483,8 +482,8 @@ sleep_until(time("2025-12-19T14:30:00Z"))
 t: Fw.Time = time("2025-12-19T14:30:00.123456Z")
 sleep_until(t)
 
-# Customize timeBase and timeContext (defaults are 0)
-t: Fw.Time = time("2025-12-19T14:30:00Z", timeBase=2, timeContext=1)
+# Customize timeBase and timeContext (defaults are TimeBase.TB_NONE and 0)
+t: Fw.Time = time("2025-12-19T14:30:00Z", timeBase=TimeBase.TB_WORKSTATION_TIME, timeContext=1)
 ```
 
 Make sure that the `Svc.FpySequencer.checkTimers` port is connected to a rate group. The sequencer only checks if a sleep is done when the port is called, so the more frequently you call it, the more accurate the wakeup time.
@@ -521,15 +520,15 @@ assert interval1 < interval2
 
 You can add a `Fw.TimeInterval` to a `Fw.Time`:
 ```py
-current: Fw.Time = {timeBase: 1, timeContext: 0, seconds: 100, useconds: 500000}
+current: Fw.Time = {timeBase: TimeBase.TB_PROC_TIME, timeContext: 0, seconds: 100, useconds: 500000}
 offset: Fw.TimeInterval = {seconds: 60}
 assert (current + offset).seconds == 160
 ```
 
 You can subtract two `Fw.Time` values to get a `Fw.TimeInterval`:
 ```py
-start: Fw.Time = {timeBase: 1, timeContext: 0, seconds: 100, useconds: 0}
-end: Fw.Time = {timeBase: 1, timeContext: 0, seconds: 105, useconds: 500000}
+start: Fw.Time = {timeBase: TimeBase.TB_PROC_TIME, timeContext: 0, seconds: 100, useconds: 0}
+end: Fw.Time = {timeBase: TimeBase.TB_PROC_TIME, timeContext: 0, seconds: 105, useconds: 500000}
 assert (end - start).seconds == 5
 ```
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,13 @@ timeout:
     CdhCore.cmdDisp.CMD_NO_OP_STRING("took more than 60 seconds :(")
 ```
 
+If you just want to wait until a condition is true without running any body, you can omit the colon and body:
+```py
+check CdhCore.cmdDisp.CommandsDispatched > 30 timeout now() + {seconds: 60}
+# execution continues here once the condition is satisfied (or times out)
+CdhCore.cmdDisp.CMD_NO_OP_STRING("done waiting!")
+```
+
 ## Getting Struct Members and Array Items
 
 You can access members of structs by name, or array elements by index:

--- a/README.md
+++ b/README.md
@@ -290,20 +290,20 @@ timeout:
     CdhCore.cmdDisp.CMD_NO_OP_STRING("took more than 60 seconds :(")
 ```
 
-Finally, you can specify a `freq` at which the condition should be checked:
+Finally, you can specify a `period` at which the condition should be checked:
 ```py
-check CdhCore.cmdDisp.CommandsDispatched > 30 freq {seconds: 1}: # check every 1 second
+check CdhCore.cmdDisp.CommandsDispatched > 30 period {seconds: 1}: # check every 1 second
     CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands!")
 ```
 
-If you don't specify a value for `freq`, the default frequency is 1 Hertz.
+If you don't specify a value for `period`, the default period is 1 second.
 
-The `timeout`, `persist` and `freq` clauses can appear in any order. They can also be spread across multiple lines:
+The `timeout`, `persist` and `period` clauses can appear in any order. They can also be spread across multiple lines:
 ```py
 check CdhCore.cmdDisp.CommandsDispatched > 30
     timeout now() + {seconds: 60}
     persist {seconds: 2}
-    freq {seconds: 1}
+    period {seconds: 1}
     CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 2 seconds!")
 timeout:
     CdhCore.cmdDisp.CMD_NO_OP_STRING("took more than 60 seconds :(")

--- a/src/fpy/desugaring.py
+++ b/src/fpy/desugaring.py
@@ -626,15 +626,32 @@ class DesugarCheckStatements(Transformer):
         #     <body>
         # else:
         #     <timeout_body>  (optional)
-        final_if = AstIf(
-            self.meta,
-            cs("result"),
-            node.body,           # Use original body
-            [],                  # No elifs
-            node.timeout_body    # Use original timeout_body (may be None)
-        )
+        #
+        # For body-less check (body is None):
+        # - No body, no timeout_body: just the while loop (wait until condition)
+        # - No body, has timeout_body: if not $check_state.result: <timeout_body>
+        result = [init_check_state, while_loop]
         
-        return [init_check_state, while_loop, final_if]
+        if node.body is not None:
+            final_if = AstIf(
+                self.meta,
+                cs("result"),
+                node.body,           # Use original body
+                [],                  # No elifs
+                node.timeout_body    # Use original timeout_body (may be None)
+            )
+            result.append(final_if)
+        elif node.timeout_body is not None:
+            final_if = AstIf(
+                self.meta,
+                self.unary("not", cs("result")),
+                node.timeout_body,   # Run timeout_body when check failed
+                [],                  # No elifs
+                None                 # No else
+            )
+            result.append(final_if)
+        
+        return result
 
 
 

--- a/src/fpy/desugaring.py
+++ b/src/fpy/desugaring.py
@@ -344,7 +344,7 @@ class DesugarCheckStatements(Transformer):
     The generated AST nodes will go through normal semantic analysis.
     
     A check statement:
-        check <condition> [timeout <timeout>] [persist <persist>] [freq <freq>]:
+        check <condition> [timeout <timeout>] [persist <persist>] [period <period>]:
             <body>
         [timeout:
             <timeout_body>]
@@ -352,7 +352,7 @@ class DesugarCheckStatements(Transformer):
     Default values:
         - timeout: no timeout (runs indefinitely until condition persists)
         - persist: 0 second interval (condition must be true once)
-        - freq: 1 second interval (check condition every second)
+        - period: 1 second interval (check condition every second)
     
     Gets desugared into (roughly):
         $check_state: $CheckState = $CheckState(...)
@@ -373,7 +373,7 @@ class DesugarCheckStatements(Transformer):
                     break
             else:
                 $check_state.last_was_true = False
-            sleep($check_state.freq.seconds, $check_state.freq.useconds)
+            sleep($check_state.period.seconds, $check_state.period.useconds)
         if $check_state.result:
             <body>
         else:
@@ -467,12 +467,12 @@ class DesugarCheckStatements(Transformer):
             return self.member(self.ident(check_state_name), attr)
         
         # Build the CheckState constructor call
-        # $CheckState(persist=<persist>, timeout=<timeout>, freq=<freq>, 
+        # $CheckState(persist=<persist>, timeout=<timeout>, period=<period>, 
         #             result=False, last_was_true=False, last_time_true=Fw.Time(0,0,0,0), time_started=now())
         
         # Handle default values:
         # - persist: default to Fw.TimeIntervalValue(0, 0) (0 second interval)
-        # - freq: default to Fw.TimeIntervalValue(1, 0) (1 second interval)
+        # - period: default to Fw.TimeIntervalValue(1, 0) (1 second interval)
         # - timeout: if not specified, use a dummy value (but we skip timeout check logic)
         
         persist_expr = (
@@ -480,8 +480,8 @@ class DesugarCheckStatements(Transformer):
             else self.call_parts(["Fw", "TimeIntervalValue"], self.number(0), self.number(0))
         )
         
-        freq_expr = (
-            copy.deepcopy(node.freq) if node.freq is not None
+        period_expr = (
+            copy.deepcopy(node.period) if node.period is not None
             else self.call_parts(["Fw", "TimeIntervalValue"], self.number(1), self.number(0))
         )
         
@@ -500,7 +500,7 @@ class DesugarCheckStatements(Transformer):
             self.qualified_name("$CheckState"),             
             persist_expr,                                   # persist
             timeout_expr_to_use,                            # timeout (absolute time)
-            freq_expr,                                      # freq
+            period_expr,                                    # period
             self.boolean(False),                            # result
             self.boolean(False),                            # last_was_true
             self.call_parts(                                # last_time_true = Fw.TimeValue(TimeBase.TB_NONE,0,0,0)
@@ -605,11 +605,11 @@ class DesugarCheckStatements(Transformer):
             [self.assign(cs("last_was_true"), self.boolean(False))]
         )
         
-        # 7. sleep($check_state.freq.seconds, $check_state.freq.useconds)
+        # 7. sleep($check_state.period.seconds, $check_state.period.useconds)
         sleep_call = self.call(
             "sleep",
-            self.member(cs("freq"), "seconds"),
-            self.member(cs("freq"), "useconds")
+            self.member(cs("period"), "seconds"),
+            self.member(cs("period"), "useconds")
         )
         
         # Add condition check and sleep to while body

--- a/src/fpy/grammar.lark
+++ b/src/fpy/grammar.lark
@@ -58,6 +58,7 @@ while_stmt: "while" expr ":" block
 # check has a conditional, optional timeout/persist/period expressions, a list of body statements,
 # and an optional list of timeout body statements
 # The clauses can appear on the same line as the condition, on separate indented lines, or mixed.
+# A body-less check (no ":" and no body) waits until the condition is satisfied, then continues.
 check_timeout: "timeout" expr
 check_persist: "persist" expr
 check_period: "period" expr
@@ -69,10 +70,14 @@ check_clause: check_timeout | check_persist | check_period
 check_clause_final: check_timeout_final | check_persist_final | check_period_final
 # Multi-line clauses: zero or more non-final clauses (each followed by newline),
 # followed by one final clause with colon, then statements at same indentation
+# Body-less variant: one or more clauses without a final colon, no body statements
 check_clauses: _NEWLINE _INDENT (check_clause _NEWLINE)* check_clause_final _NEWLINE _stmt+ _DEDENT
+             | _NEWLINE _INDENT (check_clause _NEWLINE)+ _DEDENT
 # Clauses can be inline, on indented lines, or mixed (some inline, rest indented)
+# Body-less inline: check with optional clauses terminated by newline (no ":" or body)
 check_stmt: "check" expr check_clause* ":" block ["timeout" ":" block]
           | "check" expr check_clause* check_clauses ["timeout" ":" block]
+          | "check" expr check_clause* _NEWLINE
 # -> AstCheck(condition, timeout, persist, period, body, timeout_body)
 
 

--- a/src/fpy/grammar.lark
+++ b/src/fpy/grammar.lark
@@ -55,25 +55,25 @@ while_stmt: "while" expr ":" block
 # -> AstWhile(condition, body)
 
 # check statement
-# check has a conditional, optional timeout/persist/freq expressions, a list of body statements,
+# check has a conditional, optional timeout/persist/period expressions, a list of body statements,
 # and an optional list of timeout body statements
 # The clauses can appear on the same line as the condition, on separate indented lines, or mixed.
 check_timeout: "timeout" expr
 check_persist: "persist" expr
-check_freq: "freq" expr
+check_period: "period" expr
 # For multi-line format: the last clause can have the colon attached
 check_timeout_final: "timeout" expr ":"
 check_persist_final: "persist" expr ":"
-check_freq_final: "freq" expr ":"
-check_clause: check_timeout | check_persist | check_freq
-check_clause_final: check_timeout_final | check_persist_final | check_freq_final
+check_period_final: "period" expr ":"
+check_clause: check_timeout | check_persist | check_period
+check_clause_final: check_timeout_final | check_persist_final | check_period_final
 # Multi-line clauses: zero or more non-final clauses (each followed by newline),
 # followed by one final clause with colon, then statements at same indentation
 check_clauses: _NEWLINE _INDENT (check_clause _NEWLINE)* check_clause_final _NEWLINE _stmt+ _DEDENT
 # Clauses can be inline, on indented lines, or mixed (some inline, rest indented)
 check_stmt: "check" expr check_clause* ":" block ["timeout" ":" block]
           | "check" expr check_clause* check_clauses ["timeout" ":" block]
-# -> AstCheck(condition, timeout, persist, freq, body, timeout_body)
+# -> AstCheck(condition, timeout, persist, period, body, timeout_body)
 
 
 # branching statement

--- a/src/fpy/syntax.py
+++ b/src/fpy/syntax.py
@@ -286,7 +286,7 @@ class AstCheck(Ast):
     condition: AstExpr
     timeout: Union[AstExpr, None]  # Default: no timeout
     persist: Union[AstExpr, None]  # Default: 0 second interval
-    freq: Union[AstExpr, None]    # Default: 1 second interval
+    period: Union[AstExpr, None]    # Default: 1 second interval
     body: "AstBlock"
     timeout_body: Union["AstBlock", None] = None
 
@@ -400,7 +400,7 @@ def handle_str(meta, s: str):
 
 
 # Check statement clause handlers.
-# The check_stmt grammar has multiple optional clauses (timeout, persist, freq).
+# The check_stmt grammar has multiple optional clauses (timeout, persist, period).
 # We use separate grammar rules for each clause so we can tag them and identify
 # which optional clauses were provided, regardless of how many are present.
 def handle_check_clause(tag):
@@ -433,18 +433,18 @@ def handle_check_clauses(meta, children):
 
 
 def handle_check_stmt(meta, children):
-    """Parse check statement with optional timeout/persist/freq clauses."""
+    """Parse check statement with optional timeout/persist/period clauses."""
     from fpy.error import SyntaxErrorDuringTransform
     
     condition = children[0]
     timeout = None
     persist = None
-    freq = None
+    period = None
     body = None
     timeout_body = None
     
     def set_clause(clause_type, expr):
-        nonlocal timeout, persist, freq
+        nonlocal timeout, persist, period
         if clause_type == "timeout":
             if timeout is not None:
                 raise SyntaxErrorDuringTransform(f"Duplicate 'timeout' clause in check statement", expr)
@@ -453,10 +453,10 @@ def handle_check_stmt(meta, children):
             if persist is not None:
                 raise SyntaxErrorDuringTransform(f"Duplicate 'persist' clause in check statement", expr)
             persist = expr
-        elif clause_type == "freq":
-            if freq is not None:
-                raise SyntaxErrorDuringTransform(f"Duplicate 'freq' clause in check statement", expr)
-            freq = expr
+        elif clause_type == "period":
+            if period is not None:
+                raise SyntaxErrorDuringTransform(f"Duplicate 'period' clause in check statement", expr)
+            period = expr
     
     for child in children[1:]:
         # Handle check_clauses which returns ("check_clauses_result", clauses, body)
@@ -475,7 +475,7 @@ def handle_check_stmt(meta, children):
                 timeout_body = child
     
     assert body is not None, "check statement must have a body"
-    return AstCheck(meta, condition, timeout, persist, freq, body, timeout_body)
+    return AstCheck(meta, condition, timeout, persist, period, body, timeout_body)
 
 
 def handle_parameter(meta, args):
@@ -505,10 +505,10 @@ class FpyTransformer(Transformer):
 
     check_timeout = handle_check_clause("timeout")
     check_persist = handle_check_clause("persist")
-    check_freq = handle_check_clause("freq")
+    check_period = handle_check_clause("period")
     check_timeout_final = handle_check_clause("timeout")
     check_persist_final = handle_check_clause("persist")
-    check_freq_final = handle_check_clause("freq")
+    check_period_final = handle_check_clause("period")
 
     @v_args(meta=True, inline=True)
     def check_clause(self, meta, x):

--- a/src/fpy/syntax.py
+++ b/src/fpy/syntax.py
@@ -287,7 +287,7 @@ class AstCheck(Ast):
     timeout: Union[AstExpr, None]  # Default: no timeout
     persist: Union[AstExpr, None]  # Default: 0 second interval
     period: Union[AstExpr, None]    # Default: 1 second interval
-    body: "AstBlock"
+    body: Union["AstBlock", None]  # None for body-less check
     timeout_body: Union["AstBlock", None] = None
 
 
@@ -415,7 +415,7 @@ def handle_check_clauses(meta, children):
     """Parse multi-line check clauses and body statements.
     
     Returns a tuple of (clause_list, body_stmts) where clause_list is a list of
-    (clause_type, expr) tuples and body_stmts is an AstBlock.
+    (clause_type, expr) tuples and body_stmts is an AstBlock or None (body-less).
     """
     clauses = []
     stmts = []
@@ -429,7 +429,8 @@ def handle_check_clauses(meta, children):
             stmts.append(child)
     
     # Return as a special tuple that handle_check_stmt can recognize
-    return ("check_clauses_result", clauses, AstBlock(meta, stmts))
+    body = AstBlock(meta, stmts) if stmts else None
+    return ("check_clauses_result", clauses, body)
 
 
 def handle_check_stmt(meta, children):
@@ -442,6 +443,7 @@ def handle_check_stmt(meta, children):
     period = None
     body = None
     timeout_body = None
+    body_set = False  # distinguish "body not yet assigned" from "body intentionally None (body-less)"
     
     def set_clause(clause_type, expr):
         nonlocal timeout, persist, period
@@ -464,17 +466,18 @@ def handle_check_stmt(meta, children):
             _, clauses, stmts = child
             for clause_type, expr in clauses:
                 set_clause(clause_type, expr)
-            body = stmts
+            body = stmts  # May be None for body-less multi-line check
+            body_set = True
         elif isinstance(child, tuple) and len(child) == 2:
             clause_type, expr = child
             set_clause(clause_type, expr)
         elif isinstance(child, AstBlock):
-            if body is None:
+            if not body_set:
                 body = child
+                body_set = True
             else:
                 timeout_body = child
     
-    assert body is not None, "check statement must have a body"
     return AstCheck(meta, condition, timeout, persist, period, body, timeout_body)
 
 

--- a/src/fpy/types.py
+++ b/src/fpy/types.py
@@ -608,7 +608,7 @@ CHECK_STATE = FpyType(
     members=(
         StructMember("persist", TIME_INTERVAL),
         StructMember("timeout", TIME),
-        StructMember("freq", TIME_INTERVAL),
+        StructMember("period", TIME_INTERVAL),
         StructMember("result", BOOL),
         StructMember("last_was_true", BOOL),
         StructMember("last_time_true", TIME),
@@ -617,7 +617,7 @@ CHECK_STATE = FpyType(
     json_default={
         "persist": _TIME_INTERVAL_DEFAULT,
         "timeout": _TIME_DEFAULT,
-        "freq": _TIME_INTERVAL_DEFAULT,
+        "period": _TIME_INTERVAL_DEFAULT,
         "result": False,
         "last_was_true": False,
         "last_time_true": _TIME_DEFAULT,

--- a/test/fpy/golden/check_simple.fpy
+++ b/test/fpy/golden/check_simple.fpy
@@ -1,2 +1,2 @@
-check True timeout Fw.Time(TimeBase.TB_NONE, 0, 1, 0) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 100000):
+check True timeout Fw.Time(TimeBase.TB_NONE, 0, 1, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 100000):
     pass

--- a/test/fpy/test_anon_exprs.py
+++ b/test/fpy/test_anon_exprs.py
@@ -277,14 +277,14 @@ x: U32 = [10, 20, 30][i]
 # ── Anonymous expressions in check statements ───────────────────────────
 
 class TestAnonExprInCheck:
-    """Check statements accept Fw.TimeIntervalValue for persist/freq/timeout.
+    """Check statements accept Fw.TimeIntervalValue for persist/period/timeout.
     Verify that anonymous struct syntax works in each position."""
 
     def test_check_anon_persist(self, fprime_test_api):
         """Anon struct for the persist clause."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist {seconds: 0, useconds: 0} freq Fw.TimeIntervalValue(0, 100000):
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist {seconds: 0, useconds: 0} period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 timeout:
     assert False, 1
@@ -294,10 +294,10 @@ assert check_passed
         assert_run_success(fprime_test_api, seq)
 
     def test_check_anon_freq(self, fprime_test_api):
-        """Anon struct for the freq clause."""
+        """Anon struct for the period clause."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq {seconds: 0, useconds: 100000}:
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period {seconds: 0, useconds: 100000}:
     check_passed = True
 timeout:
     assert False, 1
@@ -309,7 +309,7 @@ assert check_passed
         """Anon struct for the timeout clause (as TimeIntervalValue added to now())."""
         seq = """
 timed_out: bool = False
-check False timeout now() + {seconds: 0, useconds: 100000} persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check False timeout now() + {seconds: 0, useconds: 100000} persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     assert False, 1
 timeout:
     timed_out = True
@@ -321,7 +321,7 @@ assert timed_out
         """All three clauses use anon struct syntax simultaneously."""
         seq = """
 check_passed: bool = False
-check True timeout now() + {seconds: 1, useconds: 0} persist {seconds: 0, useconds: 0} freq {seconds: 0, useconds: 100000}:
+check True timeout now() + {seconds: 1, useconds: 0} persist {seconds: 0, useconds: 0} period {seconds: 0, useconds: 100000}:
     check_passed = True
 timeout:
     assert False, 1
@@ -333,7 +333,7 @@ assert check_passed
         """Anon struct with defaults for persist (empty → {seconds:0, useconds:0})."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist {} freq Fw.TimeIntervalValue(0, 100000):
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist {} period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 timeout:
     assert False, 1
@@ -342,10 +342,10 @@ assert check_passed
         assert_run_success(fprime_test_api, seq)
 
     def test_check_anon_freq_partial(self, fprime_test_api):
-        """Anon struct with partial members for freq (useconds only, seconds defaults to 0)."""
+        """Anon struct with partial members for period (useconds only, seconds defaults to 0)."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq {useconds: 100000}:
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period {useconds: 100000}:
     check_passed = True
 timeout:
     assert False, 1

--- a/test/fpy/test_check.py
+++ b/test/fpy/test_check.py
@@ -7,7 +7,7 @@ class TestCheckBehavior:
         """Test that check succeeds immediately when condition is true with zero persist."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 100000):
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 timeout:
     assert False, 1
@@ -19,7 +19,7 @@ assert check_passed
         """Test that check times out when condition is always false."""
         seq = """
 timed_out: bool = False
-check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     assert False, 1
 timeout:
     timed_out = True
@@ -38,7 +38,7 @@ def check_condition() -> bool:
     # Return true on 3rd evaluation
     return eval_count >= 3
 
-check check_condition() timeout time_add(now(), Fw.TimeIntervalValue(5, 0)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check check_condition() timeout time_add(now(), Fw.TimeIntervalValue(5, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     pass
 timeout:
     assert False, 1
@@ -68,7 +68,7 @@ def flaky_condition() -> bool:
 
 # Calls 1-2 are true but call 3 is false, resetting the persist timer
 # Call 4+ are true, so it should eventually succeed
-check flaky_condition() timeout time_add(now(), Fw.TimeIntervalValue(10, 0)) persist Fw.TimeIntervalValue(3, 0) freq Fw.TimeIntervalValue(1, 0):
+check flaky_condition() timeout time_add(now(), Fw.TimeIntervalValue(10, 0)) persist Fw.TimeIntervalValue(3, 0) period Fw.TimeIntervalValue(1, 0):
     pass
 timeout:
     assert False, 1
@@ -90,7 +90,7 @@ def return_true_once() -> bool:
         return True
     return False
 
-check return_true_once() timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check return_true_once() timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     exit(0)
 timeout:
     assert False, 1
@@ -103,7 +103,7 @@ class TestCheckBodies:
         """Test that check body runs when condition succeeds."""
         seq = """
 body_ran: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     body_ran = True
 assert body_ran
 """
@@ -113,7 +113,7 @@ assert body_ran
         """Test that timeout body runs when check times out."""
         seq = """
 timeout_body_ran: bool = False
-check False timeout time_add(now(), Fw.TimeIntervalValue(0, 50000)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check False timeout time_add(now(), Fw.TimeIntervalValue(0, 50000)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     assert False, 1
 timeout:
     timeout_body_ran = True
@@ -139,7 +139,7 @@ check eventually_true():
         assert_run_success(fprime_test_api, seq, timeout_s=10)
 
     def test_check_only_timeout_specified(self, fprime_test_api):
-        """Test check with only timeout specified (uses default persist=0 and freq=1s)."""
+        """Test check with only timeout specified (uses default persist=0 and period=1s)."""
         seq = """
 check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
     exit(0)
@@ -154,7 +154,7 @@ timeout:
 # Create an absolute timeout 100ms from now
 abs_timeout: Fw.Time = time_add(now(), Fw.TimeIntervalValue(0, 100000))
 result: bool = False
-check True timeout abs_timeout persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check True timeout abs_timeout persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     result = True
 timeout:
     pass
@@ -169,7 +169,7 @@ class TestCheckNesting:
         seq = """
 def do_check() -> bool:
     result: bool = False
-    check True timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+    check True timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
         result = True
     timeout:
         pass
@@ -184,7 +184,7 @@ assert do_check()
         seq = """
 outer_var: I32 = 0
 
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     outer_var = 42
 
 assert outer_var == 42
@@ -215,7 +215,7 @@ inner_timed_out: bool = False
 
 check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
     outer_passed = True
-    check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) freq Fw.TimeIntervalValue(0, 10000):
+    check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) period Fw.TimeIntervalValue(0, 10000):
         pass
     timeout:
         inner_timed_out = True
@@ -259,7 +259,7 @@ class TestCheckTypeErrors:
     def test_check_timeout_wrong_type(self, fprime_test_api):
         """Test that check timeout with wrong type gives compile error."""
         seq = """
-check True timeout 123 persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check True timeout 123 persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -267,7 +267,7 @@ check True timeout 123 persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalVa
     def test_check_condition_wrong_type(self, fprime_test_api):
         """Test that check condition must be bool, not int."""
         seq = """
-check 123 timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check 123 timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -275,7 +275,7 @@ check 123 timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeInt
     def test_check_condition_wrong_type_string(self, fprime_test_api):
         """Test that check condition must be bool, not string."""
         seq = """
-check "hello" timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check "hello" timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -283,7 +283,7 @@ check "hello" timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.Tim
     def test_check_persist_wrong_type(self, fprime_test_api):
         """Test that check persist must be TimeIntervalValue, not int."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist 123 freq Fw.TimeIntervalValue(0, 10000):
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist 123 period Fw.TimeIntervalValue(0, 10000):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -291,23 +291,23 @@ check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist 123 freq 
     def test_check_persist_wrong_type_time(self, fprime_test_api):
         """Test that check persist must be TimeIntervalValue, not Fw.Time."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist now() freq Fw.TimeIntervalValue(0, 10000):
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist now() period Fw.TimeIntervalValue(0, 10000):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
 
     def test_check_freq_wrong_type(self, fprime_test_api):
-        """Test that check freq must be TimeIntervalValue, not int."""
+        """Test that check period must be TimeIntervalValue, not int."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq 123:
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period 123:
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
 
     def test_check_freq_wrong_type_time(self, fprime_test_api):
-        """Test that check freq must be TimeIntervalValue, not Fw.Time."""
+        """Test that check period must be TimeIntervalValue, not Fw.Time."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq now():
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period now():
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -331,9 +331,9 @@ check True persist Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(2, 0)
         assert_compile_failure(fprime_test_api, seq)
 
     def test_check_duplicate_freq(self, fprime_test_api):
-        """Test that duplicate freq clauses cause a compile error."""
+        """Test that duplicate period clauses cause a compile error."""
         seq = """
-check True freq Fw.TimeIntervalValue(1, 0) freq Fw.TimeIntervalValue(2, 0):
+check True period Fw.TimeIntervalValue(1, 0) period Fw.TimeIntervalValue(2, 0):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -360,7 +360,7 @@ check_passed: bool = False
 check True
     timeout time_add(now(), Fw.TimeIntervalValue(1, 0))
     persist Fw.TimeIntervalValue(0, 0)
-    freq Fw.TimeIntervalValue(0, 100000):
+    period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 timeout:
     assert False, 1
@@ -369,11 +369,11 @@ assert check_passed
         assert_run_success(fprime_test_api, seq)
 
     def test_check_multiline_different_order(self, fprime_test_api):
-        """Test multi-line check with clauses in different order (freq, persist, timeout)."""
+        """Test multi-line check with clauses in different order (period, persist, timeout)."""
         seq = """
 check_passed: bool = False
 check True
-    freq Fw.TimeIntervalValue(0, 100000)
+    period Fw.TimeIntervalValue(0, 100000)
     persist Fw.TimeIntervalValue(0, 0)
     timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
     check_passed = True
@@ -410,10 +410,10 @@ assert check_passed
         assert_run_success(fprime_test_api, seq)
 
     def test_check_singleline_any_order_freq_first(self, fprime_test_api):
-        """Test single-line check with freq before other clauses."""
+        """Test single-line check with period before other clauses."""
         seq = """
 check_passed: bool = False
-check True freq Fw.TimeIntervalValue(0, 100000) persist Fw.TimeIntervalValue(0, 0) timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+check True period Fw.TimeIntervalValue(0, 100000) persist Fw.TimeIntervalValue(0, 0) timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
     check_passed = True
 timeout:
     assert False, 1
@@ -432,10 +432,10 @@ assert check_passed
         assert_run_success(fprime_test_api, seq)
 
     def test_check_singleline_only_freq(self, fprime_test_api):
-        """Test single-line check with only freq clause."""
+        """Test single-line check with only period clause."""
         seq = """
 check_passed: bool = False
-check True freq Fw.TimeIntervalValue(0, 100000):
+check True period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 assert check_passed
 """
@@ -447,7 +447,7 @@ assert check_passed
 timed_out: bool = False
 check False
     timeout time_add(now(), Fw.TimeIntervalValue(0, 100000))
-    freq Fw.TimeIntervalValue(0, 10000):
+    period Fw.TimeIntervalValue(0, 10000):
     assert False, 1
 timeout:
     timed_out = True
@@ -461,7 +461,7 @@ assert timed_out
 check_passed: bool = False
 check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0))
     persist Fw.TimeIntervalValue(0, 0)
-    freq Fw.TimeIntervalValue(0, 100000):
+    period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 timeout:
     assert False, 1
@@ -474,7 +474,7 @@ assert check_passed
         seq = """
 check_passed: bool = False
 check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0)
-    freq Fw.TimeIntervalValue(0, 100000):
+    period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 timeout:
     assert False, 1
@@ -541,7 +541,7 @@ assert result == 42
         """Test that return from timeout body works correctly."""
         seq = """
 def check_timeout_return() -> I64:
-    check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) freq Fw.TimeIntervalValue(0, 10000):
+    check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) period Fw.TimeIntervalValue(0, 10000):
         return 1
     timeout:
         return 42

--- a/test/fpy/test_check.py
+++ b/test/fpy/test_check.py
@@ -586,3 +586,114 @@ def check_no_timeout() -> I64:
         # The check desugars to: while True:...; if result: <body> else: <implicit>
         # The implicit else doesn't return, so we need a trailing return
         assert_compile_failure(fprime_test_api, seq)
+
+
+class TestBodylessCheck:
+
+    def test_bodyless_check_inline_true(self, fprime_test_api):
+        """Body-less check with True condition proceeds immediately."""
+        seq = """
+done: bool = False
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) period Fw.TimeIntervalValue(0, 100000)
+done = True
+assert done
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_bodyless_check_inline_with_timeout(self, fprime_test_api):
+        """Body-less check that times out (no timeout body, just proceeds)."""
+        seq = """
+check False timeout time_add(now(), Fw.TimeIntervalValue(0, 50000)) period Fw.TimeIntervalValue(0, 10000)
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_bodyless_check_inline_no_clauses(self, fprime_test_api):
+        """Body-less check with no clauses uses defaults (True passes immediately)."""
+        seq = """
+done: bool = False
+check True
+done = True
+assert done
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_bodyless_check_inline_only_timeout(self, fprime_test_api):
+        """Body-less check with only a timeout clause."""
+        seq = """
+done: bool = False
+check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0))
+done = True
+assert done
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_bodyless_check_inline_only_period(self, fprime_test_api):
+        """Body-less check with only a period clause."""
+        seq = """
+done: bool = False
+check True period Fw.TimeIntervalValue(0, 100000)
+done = True
+assert done
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_bodyless_check_multiline_clauses(self, fprime_test_api):
+        """Body-less check with multi-line clauses (no colon on last clause)."""
+        seq = """
+done: bool = False
+check True
+    timeout time_add(now(), Fw.TimeIntervalValue(1, 0))
+    period Fw.TimeIntervalValue(0, 100000)
+done = True
+assert done
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_bodyless_check_multiline_with_timeout_body(self, fprime_test_api):
+        """Body-less check with multi-line clauses and a timeout body."""
+        seq = """
+timed_out: bool = False
+check False
+    timeout time_add(now(), Fw.TimeIntervalValue(0, 50000))
+    period Fw.TimeIntervalValue(0, 10000)
+timeout:
+    timed_out = True
+assert timed_out
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_bodyless_check_waits_for_condition(self, fprime_test_api):
+        """Body-less check actually waits until the condition becomes true."""
+        seq = """
+counter: I64 = 0
+def counting_condition() -> bool:
+    counter = counter + 1
+    return counter >= 3
+
+check counting_condition() timeout time_add(now(), Fw.TimeIntervalValue(5, 0)) period Fw.TimeIntervalValue(0, 10000)
+assert counter >= 3
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_bodyless_check_inside_block(self, fprime_test_api):
+        """Body-less check inside an if block."""
+        seq = """
+done: bool = False
+if True:
+    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) period Fw.TimeIntervalValue(0, 100000)
+    done = True
+assert done
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_bodyless_check_in_function(self, fprime_test_api):
+        """Body-less check inside a function, followed by more statements."""
+        seq = """
+def wait_and_return() -> I64:
+    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) period Fw.TimeIntervalValue(0, 100000)
+    return 42
+
+result: I64 = wait_and_return()
+assert result == 42
+"""
+        assert_run_success(fprime_test_api, seq)

--- a/test/fpy/test_integration.py
+++ b/test/fpy/test_integration.py
@@ -34,14 +34,28 @@ uint: U32 = 123123
 int: I32 = I32(uint)
 assert int == 123123
 
+high_bitwidth: U32 = 16383
+low_bitwidth: U8 = U8(high_bitwidth)
+
+CdhCore.cmdDisp.CMD_NO_OP_STRING("Hello world!")
+CdhCore.cmdDisp.CMD_NO_OP_STRING(arg1="Hello world!")
+
+set_flag(Svc.Fpy.FlagId.EXIT_ON_CMD_FAIL, False)
+success: Fw.CmdResponse = CdhCore.cmdDisp.CMD_NO_OP()
+
+if success == Fw.CmdResponse.OK:
+    CdhCore.cmdDisp.CMD_NO_OP_STRING("No-op works!")
+set_flag(Svc.Fpy.FlagId.EXIT_ON_CMD_FAIL, True)
+
 CdhCore.cmdDisp.CMD_NO_OP_STRING("second 0")
 # sleep for 1 second
 sleep(1)
 CdhCore.cmdDisp.CMD_NO_OP_STRING("second 1")
 # sleep for half a second
 sleep(useconds=500_000)
+# sleep until the next checkTimers call
+sleep()
 
-value: bool = 1 > 2 and (3 + 4) != 5
 many_cmds_dispatched: bool = cmds_dispatched >= 123
 record1: Svc.DpRecord = Svc.DpRecord(0, 1, 2, 3, 4, 5, Fw.DpState.UNTRANSMITTED)
 record2: Svc.DpRecord = Svc.DpRecord(0, 1, 2, 3, 4, 5, Fw.DpState.UNTRANSMITTED)
@@ -59,6 +73,8 @@ time_interval: Fw.TimeInterval = {seconds: 15, useconds: 1000}
 
 array_var: Ref.DpDemo.U32Array = [0, 1, 2, 3, 4]
 
+enum_var: Fw.Enabled = Fw.Enabled.ENABLED
+
 counter: U64 = 0
 while counter < 100:
     counter = counter + 1
@@ -70,6 +86,10 @@ for i in 0 .. 5:
     sum = sum + i
 
 assert sum == 10
+i: I64 = 123
+for i in 0..5:
+    sum = sum + i
+assert sum == 20
 counter = 0
 while True:
     counter = counter + 1
@@ -147,6 +167,9 @@ check CdhCore.cmdDisp.CommandsDispatched > 1
 timeout:
     CdhCore.cmdDisp.CMD_NO_OP_STRING("took more than 60 seconds :(")
 
+check CdhCore.cmdDisp.CommandsDispatched > 1 timeout now() + {seconds: 60}
+CdhCore.cmdDisp.CMD_NO_OP_STRING("done waiting!")
+
 # Time functions examples
 current_time: Fw.Time = now()
 t1: Fw.Time = now()
@@ -164,6 +187,12 @@ assert (current + offset).seconds == 160
 start: Fw.Time = {timeBase: TimeBase.TB_PROC_TIME, timeContext: 0, seconds: 100, useconds: 0}
 end: Fw.Time = {timeBase: TimeBase.TB_PROC_TIME, timeContext: 0, seconds: 105, useconds: 500000}
 assert (end - start).seconds == 5
+
+parsed_time: Fw.Time = time("2025-12-19T14:30:00.123456Z")
+parsed_time_with_base: Fw.Time = time("2025-12-19T14:30:00Z", timeBase=TimeBase.TB_WORKSTATION_TIME, timeContext=1)
+
+assert 1 > 0
+exit(0)
 """
         assert_run_success(
             fprime_test_api,

--- a/test/fpy/test_integration.py
+++ b/test/fpy/test_integration.py
@@ -137,12 +137,12 @@ check CdhCore.cmdDisp.CommandsDispatched > 1 timeout now() + {seconds: 60} persi
     CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 2 seconds!")
 timeout:
     CdhCore.cmdDisp.CMD_NO_OP_STRING("took more than 60 seconds :(")
-check CdhCore.cmdDisp.CommandsDispatched > 1 freq {seconds: 1}: # check every 1 second
+check CdhCore.cmdDisp.CommandsDispatched > 1 period {seconds: 1}: # check every 1 second
     CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands!")
 check CdhCore.cmdDisp.CommandsDispatched > 1
     timeout now() + {seconds: 60}
     persist {seconds: 1}
-    freq {seconds: 1}:
+    period {seconds: 1}:
     CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 2 seconds!")
 timeout:
     CdhCore.cmdDisp.CMD_NO_OP_STRING("took more than 60 seconds :(")

--- a/test/fpy/test_parsing.py
+++ b/test/fpy/test_parsing.py
@@ -277,7 +277,7 @@ check True timeout time_add(
         seconds: 1,
         useconds: 0,
     },
-) persist {seconds: 0, useconds: 0} freq {seconds: 0, useconds: 100000}:
+) persist {seconds: 0, useconds: 0} period {seconds: 0, useconds: 100000}:
     check_passed = True
 timeout:
     assert False, 1
@@ -295,7 +295,7 @@ check True timeout now() + {
 } persist {
     seconds: 0,
     useconds: 0,
-} freq {
+} period {
     seconds: 0,
     useconds: 100000,
 }:

--- a/test/fpy/test_time_seqs.py
+++ b/test/fpy/test_time_seqs.py
@@ -1025,7 +1025,7 @@ assert result == Fw.TimeComparison.LT  # t1 < t2
 # Set timeout with timeBase=TimeBase.TB_PROC_TIME
 bad_timeout: Fw.Time = Fw.Time(TimeBase.TB_PROC_TIME, 0, 100, 0)
 
-check True timeout bad_timeout persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 100000):
+check True timeout bad_timeout persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 100000):
     pass
 timeout:
     pass
@@ -1045,8 +1045,8 @@ timeout:
 timed_out: bool = False
 
 # Set timeout to be 100ms from now
-# With freq of 10ms, we'll check ~10 times before timeout
-check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+# With period of 10ms, we'll check ~10 times before timeout
+check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     # This shouldn't run because condition is always false
     assert False, 1
 timeout:
@@ -1074,7 +1074,7 @@ def condition() -> bool:
 
 # Require condition to persist for 50ms with 10ms frequency
 # Should need ~5 checks to persist
-check condition() timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 50000) freq Fw.TimeIntervalValue(0, 10000):
+check condition() timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 50000) period Fw.TimeIntervalValue(0, 10000):
     pass
 timeout:
     assert False, 1
@@ -1117,7 +1117,7 @@ def check_time_base() -> bool:
         time_base_ok = False
     return check_count >= 3
 
-check check_time_base() timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) freq Fw.TimeIntervalValue(0, 10000):
+check check_time_base() timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     pass
 timeout:
     assert False, 1


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#4663, nasa/fprime#4850 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

* Rename `freq` to `period` in the check statement. Freq is just not true.
* Allow check without a body, to support "wait until condition true" logic

