### PR TITLE
Add log builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Fpy supports logging F Prime events:
 ```py
 log("hello world!") # creates an ACTIVITY_HI event with the text "hello world!"
 ```
+
 You can configure the severity of the event:
 ```py
 log("uh oh", Fw.LogSeverity.WARNING_HI)
@@ -73,13 +74,13 @@ Fpy supports calling any command in the F Prime dictionary:
 ```py
 CdhCore.cmdDisp.CMD_NO_OP()
 # no delay between commands
-CdhCore.cmdDisp.CMD_NO_OP_STRING("Hello world!")
+CdhCore.cmdDisp.CMD_NO_OP_STRING("hello world!")
 # the sequence waits until a command response is returned
 ```
 
 Commands arguments are type checked, and they do not need to be constants. You can pass command arguments by name:
 ```py
-CdhCore.cmdDisp.CMD_NO_OP_STRING(arg1="Hello world!")
+CdhCore.cmdDisp.CMD_NO_OP_STRING(arg1="hello world!")
 ```
 
 If a command fails and the response isn't handled, the sequence will exit with an error:
@@ -94,7 +95,7 @@ success: Fw.CmdResponse = CdhCore.exampleComponent.CMD_THAT_WILL_FAIL()
 # cmd response is handled, sequence proceeds normally
 
 if success == Fw.CmdResponse.EXECUTION_ERROR:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("Command failed!")
+    log("Command failed!")
 ```
 
 You can configure whether unhandled command failures cause the sequence to exit by setting the `flags.assert_cmd_success` Boolean flag:
@@ -266,11 +267,11 @@ You can branch off of conditionals with `if`, `elif` and `else`:
 random_value: I8 = 4 # chosen by fair dice roll. guaranteed to be random
 
 if random_value < 0:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("won't happen")
+    log("won't happen")
 elif random_value > 0 and random_value <= 6:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("should happen!")
+    log("should happen!")
 else:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("uh oh...")
+    log("uh oh...")
 ```
 
 This is particularly useful for checking telemetry channel values:
@@ -279,7 +280,7 @@ This is particularly useful for checking telemetry channel values:
 CdhCore.cmdDisp.CMD_NO_OP()
 # the commands dispatched count should be >= 1
 if CdhCore.cmdDisp.CommandsDispatched >= 1:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("should happen")
+    log("should happen")
 ```
 
 ## Check statement
@@ -287,7 +288,7 @@ if CdhCore.cmdDisp.CommandsDispatched >= 1:
 A `check` statement is like an [`if`](#ifelifelse), but its condition has to hold true (or "persist") for some amount of time.
 ```py
 check CdhCore.cmdDisp.CommandsDispatched > 30 persist {seconds: 15}:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 15 seconds!")
+    log("more than 30 commands for 15 seconds!")
 ```
 
 If you don't specify a value for `persist`, the condition only has to be true once.
@@ -295,21 +296,21 @@ If you don't specify a value for `persist`, the condition only has to be true on
 You can specify an absolute time at which the `check` should time out:
 ```py
 check CdhCore.cmdDisp.CommandsDispatched > 30 timeout now() + {seconds: 60} persist {seconds: 2}:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 2 seconds!")
+    log("more than 30 commands for 2 seconds!")
 ```
 
 You can also specify a `timeout` clause, which executes if the `check` times out:
 ```py
 check CdhCore.cmdDisp.CommandsDispatched > 30 timeout now() + {seconds: 60} persist {seconds: 2}:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 2 seconds!")
+    log("more than 30 commands for 2 seconds!")
 timeout:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("took more than 60 seconds :(")
+    log("took more than 60 seconds :(")
 ```
 
 Finally, you can specify a `period` at which the condition should be checked:
 ```py
 check CdhCore.cmdDisp.CommandsDispatched > 30 period {seconds: 1}: # check every 1 second
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands!")
+    log("more than 30 commands!")
 ```
 
 If you don't specify a value for `period`, the default period is 1 second.
@@ -320,16 +321,16 @@ check CdhCore.cmdDisp.CommandsDispatched > 30
     timeout now() + {seconds: 60}
     persist {seconds: 2}
     period {seconds: 1}
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 2 seconds!")
+    log("more than 30 commands for 2 seconds!")
 timeout:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("took more than 60 seconds :(")
+    log("took more than 60 seconds :(")
 ```
 
 If you just want to wait until a condition is true without running any body, you can omit the colon and body:
 ```py
 check CdhCore.cmdDisp.CommandsDispatched > 30 timeout now() + {seconds: 60}
 # execution continues here once the condition is satisfied (or times out)
-CdhCore.cmdDisp.CMD_NO_OP_STRING("done waiting!")
+log("done waiting!")
 ```
 
 ## Getting Struct Members and Array Items
@@ -417,7 +418,7 @@ You can define and call functions:
 ```py
 def foobar():
     if 1 + 2 == 3:
-        CdhCore.cmdDisp.CMD_NO_OP_STRING("foo")
+        log("foo")
 
 foobar()
 ```
@@ -436,7 +437,7 @@ Functions can have default argument values:
 ```py
 def greet(times: I64 = 3):
     for i in 0..times:
-        CdhCore.cmdDisp.CMD_NO_OP_STRING("hello")
+        log("hello")
 
 greet()  # uses default: prints 3 times
 greet(1) # prints once
@@ -461,7 +462,7 @@ Functions can call each other or themselves:
 def recurse(limit: U64):
     if limit == 0:
         return
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("tick")
+    log("tick")
     recurse(limit - 1)
 
 recurse(5) # prints "tick" 5 times
@@ -472,21 +473,21 @@ Functions can only be defined at the top level—not inside loops, conditionals,
 ## Relative and Absolute Sleep
 You can pause the execution of a sequence for a relative duration, or until an absolute time:
 ```py
-CdhCore.cmdDisp.CMD_NO_OP_STRING("second 0")
+log("second 0")
 # sleep for 1 second
 sleep(1)
-CdhCore.cmdDisp.CMD_NO_OP_STRING("second 1")
+log("second 1")
 # sleep for half a second
 sleep(useconds=500_000)
 
 # sleep until the next checkTimers call on the Svc.FpySequencer component
 sleep()
-CdhCore.cmdDisp.CMD_NO_OP_STRING("checkTimers called!")
+log("checkTimers called!")
 
-CdhCore.cmdDisp.CMD_NO_OP_STRING("today")
+log("today")
 # sleep until 1234567890 seconds and 0 microseconds after the epoch
 sleep_until({timeBase: TimeBase.TB_NONE, timeContext: 1, seconds: 1234567890, useconds: 0})
-CdhCore.cmdDisp.CMD_NO_OP_STRING("much later")
+log("much later")
 ```
 
 You can also use the `time()` function to parse ISO 8601 timestamps:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/fprime-community/fpy)](LICENSE)
 
 
-Fpy is a user-friendly spacecraft scripting language for the [F-Prime](https://nasa.github.io/fprime/) flight software framework.
+Fpy is a user-friendly spacecraft scripting language for the [F Prime](https://nasa.github.io/fprime/) flight software framework.
 
 ---
 
@@ -27,7 +27,7 @@ This repository contains the Fpy compiler, which emits Fpy bytecode. The Fpy byt
 
 # User's Guide
 
-This guide is a quick overview of the most important features of Fpy. It should be easy to follow for someone who has used Python and F-Prime before.
+This guide is a quick overview of the most important features of Fpy. It should be easy to follow for someone who has used Python and F Prime before.
 
 ## Compiling and Running a Sequence
 
@@ -50,9 +50,25 @@ You can compile it with `fprime-fpyc test.fpy --dictionary Ref/build-artifacts/L
 
 Make sure your deployment topology has an instance of the `Svc.FpySequencer` component. You can run the sequence by passing it in as an argument to the `Svc.FpySequencer.RUN` command.
 
+## Logging
+
+Fpy supports logging F Prime events:
+```py
+log("hello world!") # creates an ACTIVITY_HI event with the text "hello world!"
+```
+You can configure the severity of the event:
+```py
+log("uh oh", Fw.LogSeverity.WARNING_HI)
+log("oh no!", Fw.LogSeverity.FATAL)
+```
+
+All F Prime severity levels are supported.
+
+At the moment, only constant string arguments are supported. See [Strings](#strings).
+
 ## Commands
 
-Fpy supports calling any command in the F-Prime dictionary:
+Fpy supports calling any command in the F Prime dictionary:
 
 ```py
 CdhCore.cmdDisp.CMD_NO_OP()
@@ -172,7 +188,7 @@ int: I32 = I32(uint)
 
 ## Dictionary Types
 
-Fpy also has access to all structs, arrays and enums in the F-Prime dictionary:
+Fpy also has access to all structs, arrays and enums in the F Prime dictionary:
 ```py
 # you can access enum constants by name:
 enum_var: Fw.Success = Fw.Success.SUCCESS
@@ -563,7 +579,7 @@ assert 1 > 2, 123
 ```
 
 ## Strings
-Fpy does not support a fully-fledged `string` type yet. You can pass a string literal as an argument to a command, but you cannot pass a string from a telemetry channel. You also cannot store a string in a variable, or perform any string manipulation, or use any types anywhere which have strings as members or elements. This is due to F-Prime strings having a dynamic serialized size. These features will be added in a later Fpy update.
+Fpy does not support a fully-fledged `string` type yet. You can pass a string literal as an argument to a command or builtin, but you cannot pass a string from a telemetry channel. You also cannot store a string in a variable, or perform any string manipulation, or use any types anywhere which have strings as members or elements. This is due to F Prime strings having a dynamic serialized size. These features will be added in a later Fpy update.
 
 
 # Developer's Guide
@@ -575,7 +591,7 @@ Fpy does not support a fully-fledged `string` type yet. You can pass a string li
 3. Make changes to the source
 4. `pytest`
 
-## Running on a test F-Prime deployment
+## Running on a test F Prime deployment
 
 1. `git clone git@github.com:zimri-leisher/fprime-fpy-testbed`
 2. `cd fprime-fpy-testbed`

--- a/src/fpy/SPEC.md
+++ b/src/fpy/SPEC.md
@@ -125,7 +125,7 @@ Available macros:
 * `time(timestamp: String, timeBase: TimeBase = TimeBase.TB_NONE, timeContext: U8 = 0) -> Fw.TimeValue`: parses an ISO 8601 timestamp string (e.g., `"2025-12-19T14:30:00Z"` or `"2025-12-19T14:30:00.123456Z"`) at compile time and returns an `Fw.TimeValue` with the specified `timeBase` and `timeContext`. The timestamp must be in UTC with a `Z` suffix.
 * `iabs(value: I64) -> I64`: returns the absolute value of a signed 64-bit integer.
 * `fabs(value: F64) -> F64`: returns the absolute value of a 64-bit float.
-* `log(message: String, severity: LogSeverity = LogSeverity.ACTIVITY_HI)`: pushes the severity and message onto the stack, then emits a `PopEventDirective`. Both arguments must be compile-time constants.
+* `log(message: String, severity: Fw.LogSeverity = Fw.LogSeverity.ACTIVITY_HI)`: pushes the severity and message onto the stack, then emits a `PopEventDirective`. Both arguments must be compile-time constants.
 
 ## Type constructors
 Structs, arrays, and `Fw.TimeValue` expose constructors whose callable name is the fully qualified type name. Their arguments correspond to the members in declaration order (struct fields by name, array elements as `e0`, `e1`, ..., and `Fw.TimeValue` with `timeBase: TimeBase`, `timeContext: U8`, `seconds: U32`, `useconds: U32`). A constructor call serializes the provided values into a new instance of that type. `Fw.Time` is an alias for `Fw.TimeValue`, and `Fw.TimeInterval` is an alias for `Fw.TimeIntervalValue`.

--- a/src/fpy/SPEC.md
+++ b/src/fpy/SPEC.md
@@ -118,13 +118,14 @@ Inline macros behave like functions whose bodies are pre-defined sequences of by
 Available macros:
 
 * `exit(exit_code: U8)`: terminates the sequence immediately by emitting an `ExitDirective`.
-* `log(operand: F64) -> F64`: computes the natural logarithm of the operand using `FloatLogDirective` and leaves the `F64` result on the stack.
+* `flog(operand: F64) -> F64`: computes the natural logarithm of the operand using `FloatLogDirective` and leaves the `F64` result on the stack.
 * `sleep(seconds: U32 = 0, microseconds: U32 = 0)`: waits for the specified relative duration (the assembler emits `WaitRelDirective`).
 * `sleep_until(wakeup_time: Fw.TimeValue)`: waits until the supplied absolute time using `WaitAbsDirective`.
 * `now() -> Fw.TimeValue`: pushes the current time via `PushTimeDirective`.
 * `time(timestamp: String, timeBase: TimeBase = TimeBase.TB_NONE, timeContext: U8 = 0) -> Fw.TimeValue`: parses an ISO 8601 timestamp string (e.g., `"2025-12-19T14:30:00Z"` or `"2025-12-19T14:30:00.123456Z"`) at compile time and returns an `Fw.TimeValue` with the specified `timeBase` and `timeContext`. The timestamp must be in UTC with a `Z` suffix.
 * `iabs(value: I64) -> I64`: returns the absolute value of a signed 64-bit integer.
 * `fabs(value: F64) -> F64`: returns the absolute value of a 64-bit float.
+* `log(message: String, severity: LogSeverity = LogSeverity.ACTIVITY_HI)`: pushes the severity and message onto the stack, then emits a `PopEventDirective`. Both arguments must be compile-time constants.
 
 ## Type constructors
 Structs, arrays, and `Fw.TimeValue` expose constructors whose callable name is the fully qualified type name. Their arguments correspond to the members in declaration order (struct fields by name, array elements as `e0`, `e1`, ..., and `Fw.TimeValue` with `timeBase: TimeBase`, `timeContext: U8`, `seconds: U32`, `useconds: U32`). A constructor call serializes the provided values into a new instance of that type. `Fw.Time` is an alias for `Fw.TimeValue`, and `Fw.TimeInterval` is an alias for `Fw.TimeIntervalValue`.

--- a/src/fpy/SPEC.md
+++ b/src/fpy/SPEC.md
@@ -118,7 +118,7 @@ Inline macros behave like functions whose bodies are pre-defined sequences of by
 Available macros:
 
 * `exit(exit_code: U8)`: terminates the sequence immediately by emitting an `ExitDirective`.
-* `flog(operand: F64) -> F64`: computes the natural logarithm of the operand using `FloatLogDirective` and leaves the `F64` result on the stack.
+* `ln(operand: F64) -> F64`: computes the natural logarithm of the operand using `FloatLogDirective` and leaves the `F64` result on the stack.
 * `sleep(seconds: U32 = 0, microseconds: U32 = 0)`: waits for the specified relative duration (the assembler emits `WaitRelDirective`).
 * `sleep_until(wakeup_time: Fw.TimeValue)`: waits until the supplied absolute time using `WaitAbsDirective`.
 * `now() -> Fw.TimeValue`: pushes the current time via `PushTimeDirective`.

--- a/src/fpy/SPEC.md
+++ b/src/fpy/SPEC.md
@@ -125,7 +125,7 @@ Available macros:
 * `time(timestamp: String, timeBase: TimeBase = TimeBase.TB_NONE, timeContext: U8 = 0) -> Fw.TimeValue`: parses an ISO 8601 timestamp string (e.g., `"2025-12-19T14:30:00Z"` or `"2025-12-19T14:30:00.123456Z"`) at compile time and returns an `Fw.TimeValue` with the specified `timeBase` and `timeContext`. The timestamp must be in UTC with a `Z` suffix.
 * `iabs(value: I64) -> I64`: returns the absolute value of a signed 64-bit integer.
 * `fabs(value: F64) -> F64`: returns the absolute value of a 64-bit float.
-* `log(message: String, severity: Fw.LogSeverity = Fw.LogSeverity.ACTIVITY_HI)`: pushes the severity and message onto the stack, then emits a `PopEventDirective`. Both arguments must be compile-time constants.
+* `log(message: String, severity: Fw.LogSeverity = Fw.LogSeverity.ACTIVITY_HI)`: pushes the severity, message, and message size onto the stack, then emits a `PopEventDirective`. Both arguments must be compile-time constants.
 
 ## Type constructors
 Structs, arrays, and `Fw.TimeValue` expose constructors whose callable name is the fully qualified type name. Their arguments correspond to the members in declaration order (struct fields by name, array elements as `e0`, `e1`, ..., and `Fw.TimeValue` with `timeBase: TimeBase`, `timeContext: U8`, `seconds: U32`, `useconds: U32`). A constructor call serializes the provided values into a new instance of that type. `Fw.Time` is an alias for `Fw.TimeValue`, and `Fw.TimeInterval` is an alias for `Fw.TimeIntervalValue`.

--- a/src/fpy/bytecode/SPEC.md
+++ b/src/fpy/bytecode/SPEC.md
@@ -1106,3 +1106,34 @@ Stores a value to an absolute address in the stack (used for global variables), 
 | value         | bytes    | stack      | The value to store (popped from stack top). |
 
 **Requirement:**  FPY-SEQ-009
+
+## POP_EVENT (77)
+Pops a severity and message from the stack and emits an F Prime event.
+
+**Preconditions:**
+- `len(stack) >= message_size + 1`
+
+**Semantics:**
+1. Pop `message_size` bytes from the stack — this is the UTF-8 encoded message.
+2. Pop 1 byte (U8) from the stack — this is the severity.
+3. The runtime raises an F Prime event whose severity is determined by the popped value and whose payload is the popped message bytes.
+
+**Severity values:**
+| Value | FPP Severity   |
+|-------|----------------|
+| 1     | FATAL          |
+| 2     | WARNING_HI     |
+| 3     | WARNING_LO     |
+| 4     | COMMAND        |
+| 5     | ACTIVITY_HI    |
+| 6     | ACTIVITY_LO    |
+| 7     | DIAGNOSTIC     |
+
+**Error Conditions:**
+- If `len(stack) < message_size + 1`: `STACK_UNDERFLOW`
+
+| Arg Name     | Arg Type      | Source    | Description |
+|--------------|---------------|----------|-------------|
+| message_size | StackSizeType | hardcoded | Number of bytes to pop for the message. |
+| severity     | U8            | stack     | The event severity level (popped after message). |
+| message      | bytes         | stack     | UTF-8 encoded message string (popped first). |

--- a/src/fpy/bytecode/SPEC.md
+++ b/src/fpy/bytecode/SPEC.md
@@ -1108,15 +1108,17 @@ Stores a value to an absolute address in the stack (used for global variables), 
 **Requirement:**  FPY-SEQ-009
 
 ## POP_EVENT (77)
-Pops a severity and message from the stack and emits an F Prime event.
+Pops a message size, message, and severity from the stack and emits an F Prime event.
 
 **Preconditions:**
-- `len(stack) >= message_size + 1`
+- `len(stack) >= sizeof(StackSizeType)` (to pop message_size)
+- After popping message_size: `len(stack) >= message_size + sizeof(Fw.LogSeverity)`
 
 **Semantics:**
-1. Pop `message_size` bytes from the stack — this is the UTF-8 encoded message.
-2. Pop 1 byte (U8) from the stack — this is the severity.
-3. The runtime raises an F Prime event whose severity is determined by the popped value and whose payload is the popped message bytes.
+1. Pop `StackSizeType` from the stack — this is `message_size`.
+2. Pop `message_size` bytes from the stack — this is the UTF-8 encoded message.
+3. Pop `Fw.LogSeverity` (rep type U8) from the stack — this is the severity.
+4. The runtime raises an F Prime event whose severity is determined by the popped value and whose payload is the popped message bytes.
 
 **Severity values:**
 | Value | FPP Severity   |
@@ -1130,10 +1132,12 @@ Pops a severity and message from the stack and emits an F Prime event.
 | 7     | DIAGNOSTIC     |
 
 **Error Conditions:**
-- If `len(stack) < message_size + 1`: `STACK_UNDERFLOW`
+- If `len(stack) < sizeof(StackSizeType)`: `STACK_UNDERFLOW`
+- If `len(stack) < message_size + sizeof(Fw.LogSeverity)` (after popping message_size): `STACK_UNDERFLOW`
+- If severity is not a valid `Fw.LogSeverity` value: `INVALID_ARG`
 
-| Arg Name     | Arg Type      | Source    | Description |
-|--------------|---------------|----------|-------------|
-| message_size | StackSizeType | hardcoded | Number of bytes to pop for the message. |
-| severity     | U8            | stack     | The event severity level (popped after message). |
-| message      | bytes         | stack     | UTF-8 encoded message string (popped first). |
+| Arg Name     | Arg Type       | Source | Description |
+|--------------|----------------|--------|-------------|
+| message_size | StackSizeType  | stack  | Number of bytes to pop for the message. |
+| message      | bytes          | stack  | UTF-8 encoded message string. |
+| severity     | Fw.LogSeverity | stack  | The event severity level. |

--- a/src/fpy/bytecode/directives.py
+++ b/src/fpy/bytecode/directives.py
@@ -372,8 +372,7 @@ class ConstCmdDirective(Directive):
 @dataclass
 class PopEventDirective(Directive):
     opcode: ClassVar[DirectiveId] = DirectiveId.POP_EVENT
-    message_size: int
-    _FIELD_TYPES: ClassVar[dict[str, FpyType]] = {"message_size": StackSizeType}
+    _FIELD_TYPES: ClassVar[dict[str, FpyType]] = {}
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/fpy/bytecode/directives.py
+++ b/src/fpy/bytecode/directives.py
@@ -143,6 +143,7 @@ class DirectiveId(Enum):
     LOAD_ABS = 74
     STORE_ABS = 75
     STORE_ABS_CONST_OFFSET = 76
+    POP_EVENT = 77
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -366,6 +367,13 @@ class ConstCmdDirective(Directive):
     cmd_opcode: int
     args: bytes
     _FIELD_TYPES: ClassVar[dict[str, FpyType]] = {"cmd_opcode": FwOpcodeType}
+
+
+@dataclass
+class PopEventDirective(Directive):
+    opcode: ClassVar[DirectiveId] = DirectiveId.POP_EVENT
+    message_size: int
+    _FIELD_TYPES: ClassVar[dict[str, FpyType]] = {"message_size": StackSizeType}
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/fpy/compiler.py
+++ b/src/fpy/compiler.py
@@ -42,6 +42,7 @@ from fpy.types import (
     CHECK_STATE,
     CMD_RESPONSE,
     FLAGS_TYPE,
+    LOG_SEVERITY,
     TIME_COMPARISON,
     TIME_INTERVAL,
     TIME_BASE,
@@ -368,6 +369,7 @@ def _build_global_scopes(dictionary: str) -> tuple:
         BOOL.name: BOOL,
         CHECK_STATE.name: CHECK_STATE,
         FLAGS_TYPE.name: FLAGS_TYPE,
+        LOG_SEVERITY.name: LOG_SEVERITY,
     }
 
     # Collect enum constants from the final type dict (after builtins and

--- a/src/fpy/macros.py
+++ b/src/fpy/macros.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 from fpy.bytecode.directives import (
     ExitDirective,
     FloatLogDirective,
+    PopEventDirective,
     PushTimeDirective,
+    PushValDirective,
     SignedIntToFloatDirective,
     WaitAbsDirective,
     WaitRelDirective,
 )
 from fpy.ir import Ir, IrIf, IrLabel
 from fpy.syntax import Ast
-from fpy.types import INTERNAL_STRING, NOTHING, TIME, TIME_BASE, BOOL, U8, U16, U32, I64, F64, FpyValue, FpyType
+from fpy.types import INTERNAL_STRING, LOG_SEVERITY, NOTHING, TIME, TIME_BASE, BOOL, U8, U16, U32, I64, F64, FpyValue, FpyType
 from fpy.state import BuiltinFuncSymbol
 from fpy.bytecode.directives import (
     FloatLessThanDirective,
@@ -168,8 +170,8 @@ MACROS: dict[str, BuiltinFuncSymbol] = {
     "exit": BuiltinFuncSymbol(
         "exit", NOTHING, [("exit_code", U8, None)], lambda n, c: [ExitDirective()]
     ),
-    "log": BuiltinFuncSymbol(
-        "log", F64, [("operand", F64, None)], lambda n, c: [FloatLogDirective()]
+    "flog": BuiltinFuncSymbol(
+        "flog", F64, [("operand", F64, None)], lambda n, c: [FloatLogDirective()]
     ),
     "now": BuiltinFuncSymbol("now", TIME, [], lambda n, c: [PushTimeDirective()]),
     "iabs": MACRO_ABS_SIGNED_INT,
@@ -177,4 +179,17 @@ MACROS: dict[str, BuiltinFuncSymbol] = {
     # time() parses ISO 8601 timestamps at compile time
     # The generate function should never be called since this is always const-evaluated
     "time": TIME_MACRO,
+    # Event logging builtin — compile-time string + severity, defaults to ACTIVITY_HI
+    "log": BuiltinFuncSymbol(
+        "log", NOTHING, [
+            ("message", INTERNAL_STRING, None),
+            ("severity", LOG_SEVERITY, FpyValue(LOG_SEVERITY, "ACTIVITY_HI")),
+        ],
+        lambda n, c: [
+            PushValDirective(c[1].serialize()),
+            PushValDirective(c[0].val.encode("utf-8")),
+            PopEventDirective(len(c[0].val.encode("utf-8"))),
+        ],
+        const_arg_indices=frozenset({0, 1}),
+    ),
 }

--- a/src/fpy/macros.py
+++ b/src/fpy/macros.py
@@ -188,7 +188,8 @@ MACROS: dict[str, BuiltinFuncSymbol] = {
         lambda n, c: [
             PushValDirective(c[1].serialize()),
             PushValDirective(c[0].val.encode("utf-8")),
-            PopEventDirective(len(c[0].val.encode("utf-8"))),
+            PushValDirective(FpyValue(StackSizeType, len(c[0].val.encode("utf-8"))).serialize()),
+            PopEventDirective(),
         ],
         const_arg_indices=frozenset({0, 1}),
     ),

--- a/src/fpy/macros.py
+++ b/src/fpy/macros.py
@@ -170,8 +170,8 @@ MACROS: dict[str, BuiltinFuncSymbol] = {
     "exit": BuiltinFuncSymbol(
         "exit", NOTHING, [("exit_code", U8, None)], lambda n, c: [ExitDirective()]
     ),
-    "flog": BuiltinFuncSymbol(
-        "flog", F64, [("operand", F64, None)], lambda n, c: [FloatLogDirective()]
+    "ln": BuiltinFuncSymbol(
+        "ln", F64, [("operand", F64, None)], lambda n, c: [FloatLogDirective()]
     ),
     "now": BuiltinFuncSymbol("now", TIME, [], lambda n, c: [PushTimeDirective()]),
     "iabs": MACRO_ABS_SIGNED_INT,

--- a/src/fpy/model.py
+++ b/src/fpy/model.py
@@ -10,6 +10,7 @@ from fpy.bytecode.directives import (
     CallDirective,
     ConstCmdDirective,
     Directive,
+    PopEventDirective,
     FwOpcodeType,
     PeekDirective,
     ExitDirective,
@@ -82,7 +83,7 @@ from fpy.bytecode.directives import (
     IntegerTruncate64To32Directive,
     IntegerTruncate64To8Directive,
 )
-from fpy.types import FpyValue, TIME
+from fpy.types import FpyValue, LOG_SEVERITY, TIME
 from fpy.state import CmdDef
 
 debug = False
@@ -1141,4 +1142,15 @@ class FpySequencerModel:
         # and push return value if one exists
         if dir.return_val_size > 0:
             self.push(return_val)
+        return None
+
+    def handle_pop_event(self, dir: PopEventDirective):
+        if len(self.stack) < dir.message_size + 1:
+            return DirectiveErrorCode.STACK_UNDERFLOW
+        message = bytes(self.pop(type=bytes, size=dir.message_size)) if dir.message_size > 0 else b""
+        severity = self.pop(type=int, signed=False, size=1)
+        severity_names = {v: k for k, v in LOG_SEVERITY.enum_dict.items()}
+        severity_name = severity_names.get(severity, f"UNKNOWN({severity})")
+        if debug:
+            print(f"POP_EVENT [{severity_name}]: {message.decode('utf-8')}")
         return None

--- a/src/fpy/model.py
+++ b/src/fpy/model.py
@@ -1145,9 +1145,12 @@ class FpySequencerModel:
         return None
 
     def handle_pop_event(self, dir: PopEventDirective):
-        if len(self.stack) < dir.message_size + 1:
+        if len(self.stack) < StackSizeType.max_size:
             return DirectiveErrorCode.STACK_UNDERFLOW
-        message = bytes(self.pop(type=bytes, size=dir.message_size)) if dir.message_size > 0 else b""
+        message_size = self.pop(type=int, signed=False, size=StackSizeType.max_size)
+        if len(self.stack) < message_size + 1:
+            return DirectiveErrorCode.STACK_UNDERFLOW
+        message = bytes(self.pop(type=bytes, size=message_size)) if message_size > 0 else b""
         severity = self.pop(type=int, signed=False, size=1)
         severity_names = {v: k for k, v in LOG_SEVERITY.enum_dict.items()}
         severity_name = severity_names.get(severity, f"UNKNOWN({severity})")

--- a/src/fpy/types.py
+++ b/src/fpy/types.py
@@ -352,7 +352,7 @@ TIME_BASE = FpyType(
 
 LOG_SEVERITY = FpyType(
     TypeKind.ENUM,
-    "LogSeverity",
+    "Fw.LogSeverity",
     enum_dict={
         "FATAL": 1,
         "WARNING_HI": 2,

--- a/src/fpy/types.py
+++ b/src/fpy/types.py
@@ -350,6 +350,21 @@ TIME_BASE = FpyType(
     rep_type=U16,
 )
 
+LOG_SEVERITY = FpyType(
+    TypeKind.ENUM,
+    "LogSeverity",
+    enum_dict={
+        "FATAL": 1,
+        "WARNING_HI": 2,
+        "WARNING_LO": 3,
+        "COMMAND": 4,
+        "ACTIVITY_HI": 5,
+        "ACTIVITY_LO": 6,
+        "DIAGNOSTIC": 7,
+    },
+    rep_type=U8,
+)
+
 TIME = FpyType(
     TypeKind.STRUCT,
     "Fw.TimeValue",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,7 @@ def pytest_addoption(parser):
         "--use-gds",
         action="store_true",
         default=False,
-        help="Run sequences against a live F-Prime GDS instead of the Python model",
+        help="Run sequences against a live F Prime GDS instead of the Python model",
     )
 
 

--- a/test/fpy/test_arithmetic.py
+++ b/test/fpy/test_arithmetic.py
@@ -282,7 +282,7 @@ exit(1)
 
     def test_log(self, fprime_test_api):
         seq = """
-if flog(4.0) > 1.385 and flog(4.0) < 1.387:
+if ln(4.0) > 1.385 and ln(4.0) < 1.387:
     exit(0)
 exit(1)
 """

--- a/test/fpy/test_arithmetic.py
+++ b/test/fpy/test_arithmetic.py
@@ -282,7 +282,7 @@ exit(1)
 
     def test_log(self, fprime_test_api):
         seq = """
-if log(4.0) > 1.385 and log(4.0) < 1.387:
+if flog(4.0) > 1.385 and flog(4.0) < 1.387:
     exit(0)
 exit(1)
 """

--- a/test/fpy/test_integration.py
+++ b/test/fpy/test_integration.py
@@ -38,10 +38,10 @@ assert int == 123123
 high_bitwidth: U32 = 16383
 low_bitwidth: U8 = U8(high_bitwidth)
 
-CdhCore.cmdDisp.CMD_NO_OP_STRING("second 0")
+log("second 0")
 # sleep for 1 second
 sleep(1)
-CdhCore.cmdDisp.CMD_NO_OP_STRING("second 1")
+log("second 1")
 # sleep for half a second
 sleep(useconds=500_000)
 # sleep until the next checkTimers call
@@ -54,11 +54,11 @@ records_equal: bool = record1 == record2 # == True
 random_value: I8 = 4 # chosen by fair dice roll. guaranteed to be random
 
 if random_value < 0:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("won't happen")
+    log("won't happen")
 elif random_value > 0 and random_value <= 6:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("should happen!")
+    log("should happen!")
 else:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("uh oh...")
+    log("uh oh...")
 
 time_interval: Fw.TimeInterval = {seconds: 15, useconds: 1000}
 
@@ -108,7 +108,7 @@ counter_global: I64 = 0
 
 def foobar():
     if 1 + 2 == 3:
-        CdhCore.cmdDisp.CMD_NO_OP_STRING("foo")
+        log("foo")
 
 foobar()
 
@@ -119,7 +119,7 @@ assert add_vals(1, 2) == 3
 
 def greet(times: I64 = 3):
     for i in 0..times:
-        CdhCore.cmdDisp.CMD_NO_OP_STRING("hello")
+        log("hello")
 
 greet()  # uses default: prints 3 times
 greet(1) # prints once
@@ -134,32 +134,32 @@ assert counter_global == 2
 def recurse(limit: U64):
     if limit == 0:
         return
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("tick")
+    log("tick")
     recurse(limit - 1)
 
 recurse(5) # prints "tick" 5 times
 
 
 check CdhCore.cmdDisp.CommandsDispatched > 1 persist {seconds: 1}:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 15 seconds!")
+    log("more than 30 commands for 15 seconds!")
 check CdhCore.cmdDisp.CommandsDispatched > 1 timeout now() + {seconds: 60} persist {seconds: 1}:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 2 seconds!")
+    log("more than 30 commands for 2 seconds!")
 check CdhCore.cmdDisp.CommandsDispatched > 1 timeout now() + {seconds: 60} persist {seconds: 1}:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 2 seconds!")
+    log("more than 30 commands for 2 seconds!")
 timeout:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("took more than 60 seconds :(")
+    log("took more than 60 seconds :(")
 check CdhCore.cmdDisp.CommandsDispatched > 1 period {seconds: 1}: # check every 1 second
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands!")
+    log("more than 30 commands!")
 check CdhCore.cmdDisp.CommandsDispatched > 1
     timeout now() + {seconds: 60}
     persist {seconds: 1}
     period {seconds: 1}:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("more than 30 commands for 2 seconds!")
+    log("more than 30 commands for 2 seconds!")
 timeout:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("took more than 60 seconds :(")
+    log("took more than 60 seconds :(")
 
 check CdhCore.cmdDisp.CommandsDispatched > 1 timeout now() + {seconds: 60}
-CdhCore.cmdDisp.CMD_NO_OP_STRING("done waiting!")
+log("done waiting!")
 
 # Time functions examples
 current_time: Fw.Time = now()
@@ -195,7 +195,7 @@ success: Fw.CmdResponse = Ref.cmdSeq.RUN("", Svc.FpySequencer.BlockState.NO_BLOC
 # cmd response is handled, sequence proceeds normally
 
 if success == Fw.CmdResponse.OK:
-    CdhCore.cmdDisp.CMD_NO_OP_STRING("No-op works!")
+    log("No-op works!")
 
 parsed_time: Fw.Time = time("2025-12-19T14:30:00.123456Z")
 parsed_time_with_base: Fw.Time = time("2025-12-19T14:30:00Z", timeBase=TimeBase.TB_WORKSTATION_TIME, timeContext=1)

--- a/test/fpy/test_integration.py
+++ b/test/fpy/test_integration.py
@@ -200,6 +200,11 @@ if success == Fw.CmdResponse.OK:
 parsed_time: Fw.Time = time("2025-12-19T14:30:00.123456Z")
 parsed_time_with_base: Fw.Time = time("2025-12-19T14:30:00Z", timeBase=TimeBase.TB_WORKSTATION_TIME, timeContext=1)
 
+# Logging
+log("hello world!")
+log("uh oh", Fw.LogSeverity.WARNING_HI)
+log("oh no!", Fw.LogSeverity.FATAL)
+
 assert 1 > 0
 exit(0)
 """

--- a/test/fpy/test_logging.py
+++ b/test/fpy/test_logging.py
@@ -16,7 +16,7 @@ log("hello world")
 
     def test_explicit_severity(self, fprime_test_api):
         seq = '''
-log("oh no", LogSeverity.FATAL)
+log("oh no", Fw.LogSeverity.FATAL)
 '''
         assert_run_success(fprime_test_api, seq)
 
@@ -33,7 +33,7 @@ log("test message")
 
     def test_explicit_fatal(self, fprime_test_api):
         seq = '''
-log("critical", LogSeverity.FATAL)
+log("critical", Fw.LogSeverity.FATAL)
 '''
         directives = compile_seq(fprime_test_api, seq)
         push_vals = [d for d in directives if isinstance(d, PushValDirective)]
@@ -44,7 +44,7 @@ log("critical", LogSeverity.FATAL)
 
     def test_explicit_warning_hi(self, fprime_test_api):
         seq = '''
-log("watch out", LogSeverity.WARNING_HI)
+log("watch out", Fw.LogSeverity.WARNING_HI)
 '''
         directives = compile_seq(fprime_test_api, seq)
         push_vals = [d for d in directives if isinstance(d, PushValDirective)]
@@ -78,8 +78,8 @@ log("roundtrip test")
     def test_multiple_events(self, fprime_test_api):
         seq = '''
 log("step 1")
-log("step 2", LogSeverity.WARNING_HI)
-log("step 3", LogSeverity.FATAL)
+log("step 2", Fw.LogSeverity.WARNING_HI)
+log("step 3", Fw.LogSeverity.FATAL)
 '''
         directives = compile_seq(fprime_test_api, seq)
         pop_dirs = [d for d in directives if isinstance(d, PopEventDirective)]

--- a/test/fpy/test_logging.py
+++ b/test/fpy/test_logging.py
@@ -26,10 +26,10 @@ log("test message")
 '''
         directives = compile_seq(fprime_test_api, seq)
         push_vals = [d for d in directives if isinstance(d, PushValDirective)]
-        assert len(push_vals) >= 2
+        assert len(push_vals) >= 3
         # ACTIVITY_HI = 5
-        assert push_vals[-2].val == bytes([5])
-        assert push_vals[-1].val == b"test message"
+        assert push_vals[-3].val == bytes([5])
+        assert push_vals[-2].val == b"test message"
 
     def test_explicit_fatal(self, fprime_test_api):
         seq = '''
@@ -37,10 +37,10 @@ log("critical", Fw.LogSeverity.FATAL)
 '''
         directives = compile_seq(fprime_test_api, seq)
         push_vals = [d for d in directives if isinstance(d, PushValDirective)]
-        assert len(push_vals) >= 2
+        assert len(push_vals) >= 3
         # FATAL = 1
-        assert push_vals[-2].val == bytes([1])
-        assert push_vals[-1].val == b"critical"
+        assert push_vals[-3].val == bytes([1])
+        assert push_vals[-2].val == b"critical"
 
     def test_explicit_warning_hi(self, fprime_test_api):
         seq = '''
@@ -48,9 +48,9 @@ log("watch out", Fw.LogSeverity.WARNING_HI)
 '''
         directives = compile_seq(fprime_test_api, seq)
         push_vals = [d for d in directives if isinstance(d, PushValDirective)]
-        assert len(push_vals) >= 2
+        assert len(push_vals) >= 3
         # WARNING_HI = 2
-        assert push_vals[-2].val == bytes([2])
+        assert push_vals[-3].val == bytes([2])
 
     def test_emits_pop_event_directive(self, fprime_test_api):
         seq = '''
@@ -59,7 +59,10 @@ log("test")
         directives = compile_seq(fprime_test_api, seq)
         pop_dirs = [d for d in directives if isinstance(d, PopEventDirective)]
         assert len(pop_dirs) == 1
-        assert pop_dirs[0].message_size == len(b"test")
+        # message_size should be pushed onto the stack before POP_EVENT
+        push_vals = [d for d in directives if isinstance(d, PushValDirective)]
+        # Last push before POP_EVENT should be the message size (U32 big-endian)
+        assert push_vals[-1].val == len(b"test").to_bytes(4, "big")
 
     def test_serialization_roundtrip(self, fprime_test_api):
         seq = '''
@@ -73,7 +76,6 @@ log("roundtrip test")
         serialized = original.serialize()
         _, deserialized = Directive.deserialize(serialized, 0)
         assert isinstance(deserialized, PopEventDirective)
-        assert deserialized.message_size == original.message_size
 
     def test_multiple_events(self, fprime_test_api):
         seq = '''

--- a/test/fpy/test_logging.py
+++ b/test/fpy/test_logging.py
@@ -1,3 +1,4 @@
+import pytest
 from fpy.bytecode.directives import Directive, PopEventDirective, PushValDirective
 from fpy.test_helpers import (
     assert_compile_failure,
@@ -14,6 +15,7 @@ log("hello world")
 '''
         assert_run_success(fprime_test_api, seq)
 
+    @pytest.mark.skipif("config.getoption('--use-gds')", reason="FATAL severity kills the program on the GDS")
     def test_explicit_severity(self, fprime_test_api):
         seq = '''
 log("oh no", Fw.LogSeverity.FATAL)
@@ -79,13 +81,15 @@ log("roundtrip test")
 
     def test_multiple_events(self, fprime_test_api):
         seq = '''
-log("step 1")
-log("step 2", Fw.LogSeverity.WARNING_HI)
-log("step 3", Fw.LogSeverity.FATAL)
+log("test")
+log("test", Fw.LogSeverity.DIAGNOSTIC)
+log("test", Fw.LogSeverity.COMMAND)
+log("test", Fw.LogSeverity.ACTIVITY_HI)
+log("test", Fw.LogSeverity.ACTIVITY_LO)
+log("test", Fw.LogSeverity.WARNING_HI)
+log("test", Fw.LogSeverity.WARNING_LO)
 '''
-        directives = compile_seq(fprime_test_api, seq)
-        pop_dirs = [d for d in directives if isinstance(d, PopEventDirective)]
-        assert len(pop_dirs) == 3
+        assert_run_success(fprime_test_api, seq)
 
     def test_non_literal_message_rejected(self, fprime_test_api):
         seq = '''

--- a/test/fpy/test_logging.py
+++ b/test/fpy/test_logging.py
@@ -1,0 +1,99 @@
+from fpy.bytecode.directives import Directive, PopEventDirective, PushValDirective
+from fpy.test_helpers import (
+    assert_compile_failure,
+    assert_run_success,
+    compile_seq,
+)
+
+
+class TestLog:
+
+    def test_default_severity(self, fprime_test_api):
+        seq = '''
+log("hello world")
+'''
+        assert_run_success(fprime_test_api, seq)
+
+    def test_explicit_severity(self, fprime_test_api):
+        seq = '''
+log("oh no", LogSeverity.FATAL)
+'''
+        assert_run_success(fprime_test_api, seq)
+
+    def test_default_severity_is_activity_hi(self, fprime_test_api):
+        seq = '''
+log("test message")
+'''
+        directives = compile_seq(fprime_test_api, seq)
+        push_vals = [d for d in directives if isinstance(d, PushValDirective)]
+        assert len(push_vals) >= 2
+        # ACTIVITY_HI = 5
+        assert push_vals[-2].val == bytes([5])
+        assert push_vals[-1].val == b"test message"
+
+    def test_explicit_fatal(self, fprime_test_api):
+        seq = '''
+log("critical", LogSeverity.FATAL)
+'''
+        directives = compile_seq(fprime_test_api, seq)
+        push_vals = [d for d in directives if isinstance(d, PushValDirective)]
+        assert len(push_vals) >= 2
+        # FATAL = 1
+        assert push_vals[-2].val == bytes([1])
+        assert push_vals[-1].val == b"critical"
+
+    def test_explicit_warning_hi(self, fprime_test_api):
+        seq = '''
+log("watch out", LogSeverity.WARNING_HI)
+'''
+        directives = compile_seq(fprime_test_api, seq)
+        push_vals = [d for d in directives if isinstance(d, PushValDirective)]
+        assert len(push_vals) >= 2
+        # WARNING_HI = 2
+        assert push_vals[-2].val == bytes([2])
+
+    def test_emits_pop_event_directive(self, fprime_test_api):
+        seq = '''
+log("test")
+'''
+        directives = compile_seq(fprime_test_api, seq)
+        pop_dirs = [d for d in directives if isinstance(d, PopEventDirective)]
+        assert len(pop_dirs) == 1
+        assert pop_dirs[0].message_size == len(b"test")
+
+    def test_serialization_roundtrip(self, fprime_test_api):
+        seq = '''
+log("roundtrip test")
+'''
+        directives = compile_seq(fprime_test_api, seq)
+        pop_dirs = [d for d in directives if isinstance(d, PopEventDirective)]
+        assert len(pop_dirs) == 1
+
+        original = pop_dirs[0]
+        serialized = original.serialize()
+        _, deserialized = Directive.deserialize(serialized, 0)
+        assert isinstance(deserialized, PopEventDirective)
+        assert deserialized.message_size == original.message_size
+
+    def test_multiple_events(self, fprime_test_api):
+        seq = '''
+log("step 1")
+log("step 2", LogSeverity.WARNING_HI)
+log("step 3", LogSeverity.FATAL)
+'''
+        directives = compile_seq(fprime_test_api, seq)
+        pop_dirs = [d for d in directives if isinstance(d, PopEventDirective)]
+        assert len(pop_dirs) == 3
+
+    def test_non_literal_message_rejected(self, fprime_test_api):
+        seq = '''
+x: U32 = 42
+log(x)
+'''
+        assert_compile_failure(fprime_test_api, seq)
+
+    def test_empty_string(self, fprime_test_api):
+        seq = '''
+log("")
+'''
+        assert_run_success(fprime_test_api, seq)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#4949 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

* Add a builtin `log` function (rename math logarithm func to `ln`)
* Takes two args: a constant string, and a constant `Fw.LogSeverity`
* Adds a new directive: PopEvent, which pops a message and severity off the stack and will raise an event

## Rationale

This is useful for printing debugging or operational information from a sequence. Currently, the cmddisp no_op_string cmd is used for printing, but that doesn't say which sequence the string is from.

