### PR TITLE
Depend tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ fprime-fpy-model = "fpy.main:model_main"
 fprime-fpy-asm = "fpy.main:assemble_main"
 fprime-fpy-disasm = "fpy.main:disassemble_main"
 fprime-fpy-cmd = "fpy.main:cmd_main"
+fprime-fpy-depend = "fpy.main:depend_main"
 
 ####
 # setuptools_scm dynamically generates version number from git, as well as automatically

--- a/src/fpy/compiler.py
+++ b/src/fpy/compiler.py
@@ -642,6 +642,8 @@ def ast_to_dependencies(
 
     discover = CollectSequenceDependencies()
     discover.run(body, state)
+    if state.errors:
+        return state.errors[0]
 
     if ground_binary_dir is not None:
         return [str(Path(ground_binary_dir) / name) for name in discover.bin_names]

--- a/src/fpy/compiler.py
+++ b/src/fpy/compiler.py
@@ -28,6 +28,7 @@ from fpy.semantics import (
     CheckReturnInFunc,
     CheckUseBeforeDefine,
     CheckSequenceArgs,
+    CollectSequenceDependencies,
     CreateVariablesAndFuncs,
     PickTypesAndResolveFields,
     ResolveQualifiedNames,
@@ -603,3 +604,45 @@ def ast_to_directives(
 
     # all the ir is guaranteed to have been converted to directives by now by FinalChecks
     return ir, state.this_seq_arg_specs
+
+
+def ast_to_dependencies(
+    body: AstBlock,
+    dictionary: str,
+    ground_binary_dir: str | None = None,
+) -> list[str] | CompileError:
+    """Return the list of .bin paths that a sequence source file depends on.
+
+    Runs only the passes needed to resolve command symbols — does not attempt
+    to read the binary files, so this works before any binaries are compiled.
+    """
+    state = get_base_compile_state(dictionary, ground_binary_dir=ground_binary_dir)
+    state.root = body
+
+    pre_builtin_passes = [CheckSequenceMetadataDefinedAtTop()]
+    for compile_pass in pre_builtin_passes:
+        compile_pass.run(body, state)
+        if state.errors:
+            return state.errors[0]
+
+    import copy
+    body.stmts = copy.deepcopy(_get_builtin_library_ast().stmts) + body.stmts
+
+    discovery_passes: list[Visitor] = [
+        DesugarCheckStatements(),
+        AssignIds(),
+        CreateScopes(),
+        CreateVariablesAndFuncs(),
+        ResolveQualifiedNames(),
+    ]
+    for compile_pass in discovery_passes:
+        compile_pass.run(body, state)
+        if state.errors:
+            return state.errors[0]
+
+    discover = CollectSequenceDependencies()
+    discover.run(body, state)
+
+    if ground_binary_dir is not None:
+        return [str(Path(ground_binary_dir) / name) for name in discover.bin_names]
+    return discover.bin_names

--- a/src/fpy/main.py
+++ b/src/fpy/main.py
@@ -24,7 +24,7 @@ from fpy.bytecode.directives import ConstCmdDirective, StackCmdDirective
 import fpy.error
 import fpy.model
 from fpy.model import DirectiveErrorCode, FpySequencerModel
-from fpy.compiler import text_to_ast, ast_to_directives
+from fpy.compiler import text_to_ast, ast_to_directives, ast_to_dependencies
 from fpy.dictionary import load_dictionary
 
 
@@ -463,3 +463,64 @@ def cmd_main(args: list[str] = None):
         except Exception as e:
             print(f"Failed to send command: {e}", file=sys.stderr)
             sys.exit(1)
+
+
+def depend_main(args: list[str] = None):
+    arg_parser = argparse.ArgumentParser(
+        description=f"Fpy dependency tool {get_version_str()}"
+    )
+    arg_parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {get_version_str()}"
+    )
+    arg_parser.add_argument("input", type=Path, help="The input .fpy file")
+    arg_parser.add_argument(
+        "-d",
+        "--dictionary",
+        type=Path,
+        required=True,
+        help="The FPrime dictionary .json file",
+    )
+    arg_parser.add_argument(
+        "-g",
+        "--ground-binary-dir",
+        type=Path,
+        required=False,
+        default=None,
+        help="Local directory to resolve .bin file paths for sequence calls (default: input file directory)",
+    )
+    if args is not None:
+        parsed_args = arg_parser.parse_args(args)
+    else:
+        parsed_args = arg_parser.parse_args()
+
+    if not parsed_args.input.exists():
+        print(f"Input file {parsed_args.input} does not exist", file=sys.stderr)
+        sys.exit(1)
+    fpy.error.file_name = str(parsed_args.input)
+
+    ground_binary_dir = parsed_args.ground_binary_dir
+    if ground_binary_dir is None:
+        ground_binary_dir = parsed_args.input.parent
+
+    try:
+        body = text_to_ast(parsed_args.input.read_text())
+    except RecursionError:
+        print("Recursion limit exceeded in parsing", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        result = ast_to_dependencies(
+            body,
+            parsed_args.dictionary,
+            ground_binary_dir=str(ground_binary_dir.resolve()),
+        )
+    except RecursionError:
+        print("Recursion limit exceeded in compiling", file=sys.stderr)
+        sys.exit(1)
+
+    if isinstance(result, fpy.error.CompileError):
+        print(result, file=sys.stderr)
+        sys.exit(1)
+
+    for dep in result:
+        print(dep)

--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -903,30 +903,33 @@ class ResolveSequenceDependencies(TopDownVisitor):
 
     For each call to a seq-run command with a string-literal filename,
     reads the target .bin header and resolves its argument types.
-    Results are stored in state.seq_dependencies so that later passes
-    (and external tools) can access them without file I/O.
+    Results are stored in state.called_seq_arg_specs so that later passes
+    can use them without file I/O.
     """
 
-    def visit_AstFuncCall(self, node: AstFuncCall, state: CompileState):
+    def _get_bin_name(self, node: AstFuncCall, state: CompileState) -> str | None:
+        """Return the .bin filename for a seq-run-with-args call, or None.
+
+        Reports a compile error if the filename argument is not a string literal.
+        """
         func = state.resolved_symbols.get(node.func)
         if not is_instance_compat(func, CommandSymbol) or not func.is_seq_run_with_args:
-            return
-
+            return None
         if not node.args or len(node.args) < 1:
             # Missing args will be caught by build_resolved_call_args (too few arguments)
-            return
-
+            return None
         file_name_arg = node.args[0]
         if not is_instance_compat(file_name_arg, AstString):
             state.err(
                 "Sequence file name must be a string literal",
                 file_name_arg,
             )
-            return
+            return None
+        return file_name_arg.value
 
-        bin_name = file_name_arg.value
-        if bin_name in state.called_seq_arg_specs:
-            # Already resolved (e.g. same sequence called twice)
+    def visit_AstFuncCall(self, node: AstFuncCall, state: CompileState):
+        bin_name = self._get_bin_name(node, state)
+        if bin_name is None or bin_name in state.called_seq_arg_specs:
             return
 
         ground_binary_dir = state.ground_binary_dir
@@ -941,7 +944,7 @@ class ResolveSequenceDependencies(TopDownVisitor):
         if not bin_path.exists():
             state.err(
                 f"Compiled sequence binary not found: {bin_path}",
-                file_name_arg,
+                node.args[0],
             )
             return
 
@@ -950,7 +953,7 @@ class ResolveSequenceDependencies(TopDownVisitor):
         except Exception as e:
             state.err(
                 f"Failed to read sequence binary {bin_path}: {e}",
-                file_name_arg,
+                node.args[0],
             )
             return
 
@@ -959,7 +962,7 @@ class ResolveSequenceDependencies(TopDownVisitor):
         except RuntimeError as e:
             state.err(
                 f"Failed to resolve argument types from {bin_path}: {e}",
-                file_name_arg,
+                node.args[0],
             )
             return
 
@@ -967,9 +970,31 @@ class ResolveSequenceDependencies(TopDownVisitor):
 
         # Build an extended CommandSymbol that includes the target sequence's
         # parameters so that standard arg resolution works in PickTypes.
+        func = state.resolved_symbols.get(node.func)
         extra_args = [(name, t, None) for name, t in target_arg_types]
         extended_func = dc_replace(func, args=func.args + extra_args)
         state.resolved_symbols[node.func] = extended_func
+
+
+class CollectSequenceDependencies(ResolveSequenceDependencies):
+    """Collect .bin filenames from seq-run-with-args calls without reading binaries.
+
+    Use this instead of ResolveSequenceDependencies when you only need the
+    dependency list (e.g. the fprime-fpy-depend tool) and the binaries may
+    not exist yet.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.bin_names: list[str] = []
+        self._seen: set[str] = set()
+
+    def visit_AstFuncCall(self, node: AstFuncCall, state: CompileState):
+        bin_name = self._get_bin_name(node, state)
+        if bin_name is None or bin_name in self._seen:
+            return
+        self._seen.add(bin_name)
+        self.bin_names.append(bin_name)
 
 
 class PickTypesAndResolveFields(Visitor):

--- a/test/fpy/test_depend.py
+++ b/test/fpy/test_depend.py
@@ -1,0 +1,183 @@
+"""Integration tests for the fprime-fpy-depend tool (ast_to_dependencies / depend_main).
+
+These tests exercise the real compiler pipeline. The key property under test is
+that dependency discovery works even when the referenced .bin files do not exist
+yet — the whole point of the tool is to let build systems determine compile order
+before any binaries have been produced.
+"""
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import fpy.error
+from fpy.compiler import ast_to_dependencies, text_to_ast
+from fpy.test_helpers import default_dictionary
+
+
+def _collect(seq: str, ground_binary_dir: str = None) -> list[str]:
+    """Run ast_to_dependencies on a sequence string; return the dependency list."""
+    fpy.error.file_name = "<test>"
+    body = text_to_ast(seq)
+    assert body is not None
+    result = ast_to_dependencies(body, default_dictionary, ground_binary_dir=ground_binary_dir)
+    assert not isinstance(result, fpy.error.CompileError), f"Unexpected error: {result}"
+    return result
+
+
+class TestNoDependencies:
+    def test_empty_sequence(self):
+        assert _collect("") == []
+
+    def test_regular_command_is_not_a_dep(self):
+        assert _collect("CdhCore.cmdDisp.CMD_NO_OP()\n") == []
+
+    def test_seq_run_without_args_is_not_a_dep(self):
+        # RUN (no varargs) is not flagged as a seq-run-with-args command
+        assert _collect('Ref.seqDisp.RUN("seq.bin", Fw.Wait.WAIT)\n') == []
+
+
+class TestSingleDependency:
+    def test_bin_name_resolved_with_ground_binary_dir(self):
+        seq = 'Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.WAIT)\n'
+        deps = _collect(seq, ground_binary_dir="/tmp/bins")
+        assert deps == ["/tmp/bins/child.bin"]
+
+    def test_bin_does_not_need_to_exist(self):
+        # The main differentiator from the compiler: missing binary is not an error
+        seq = 'Ref.seqDisp.RUN_ARGS("nonexistent.bin", Fw.Wait.WAIT)\n'
+        deps = _collect(seq, ground_binary_dir="/tmp/bins")
+        assert deps == ["/tmp/bins/nonexistent.bin"]
+
+    def test_seq_called_in_if_branch(self):
+        seq = """\
+x: I32 = 1
+if x == 1:
+    Ref.seqDisp.RUN_ARGS("branch.bin", Fw.Wait.WAIT)
+"""
+        deps = _collect(seq, ground_binary_dir="/tmp")
+        assert deps == ["/tmp/branch.bin"]
+
+    def test_seq_called_in_while_loop(self):
+        seq = """\
+x: I32 = 3
+while x > 0:
+    Ref.seqDisp.RUN_ARGS("loop.bin", Fw.Wait.NO_WAIT)
+    x = x - 1
+"""
+        deps = _collect(seq, ground_binary_dir="/tmp")
+        assert deps == ["/tmp/loop.bin"]
+
+    def test_seq_called_inside_function(self):
+        seq = """\
+def run_it():
+    Ref.seqDisp.RUN_ARGS("helper.bin", Fw.Wait.WAIT)
+run_it()
+"""
+        deps = _collect(seq, ground_binary_dir="/tmp")
+        assert deps == ["/tmp/helper.bin"]
+
+
+class TestMultipleDependencies:
+    def test_two_distinct_bins(self):
+        seq = """\
+Ref.seqDisp.RUN_ARGS("a.bin", Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS("b.bin", Fw.Wait.WAIT)
+"""
+        deps = _collect(seq, ground_binary_dir="/tmp")
+        assert deps == ["/tmp/a.bin", "/tmp/b.bin"]
+
+    def test_order_matches_source_order(self):
+        seq = """\
+Ref.seqDisp.RUN_ARGS("first.bin", Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS("second.bin", Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS("third.bin", Fw.Wait.WAIT)
+"""
+        deps = _collect(seq, ground_binary_dir="/tmp")
+        assert deps == ["/tmp/first.bin", "/tmp/second.bin", "/tmp/third.bin"]
+
+    def test_duplicate_call_deduplicated(self):
+        seq = """\
+Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.NO_WAIT)
+"""
+        deps = _collect(seq, ground_binary_dir="/tmp")
+        assert deps == ["/tmp/child.bin"]
+
+    def test_mix_of_seq_run_and_regular_commands(self):
+        seq = """\
+CdhCore.cmdDisp.CMD_NO_OP()
+Ref.seqDisp.RUN_ARGS("only_this.bin", Fw.Wait.WAIT)
+CdhCore.cmdDisp.CMD_NO_OP()
+"""
+        deps = _collect(seq, ground_binary_dir="/tmp")
+        assert deps == ["/tmp/only_this.bin"]
+
+
+class TestGroundBinaryDirHandling:
+    def test_ground_binary_dir_prepended_to_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            seq = 'Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.WAIT)\n'
+            deps = _collect(seq, ground_binary_dir=tmpdir)
+            assert deps == [str(Path(tmpdir) / "child.bin")]
+
+    def test_no_ground_binary_dir_returns_bare_names(self):
+        # Without a ground_binary_dir the raw filename is returned as-is
+        seq = 'Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.WAIT)\n'
+        deps = _collect(seq, ground_binary_dir=None)
+        assert deps == ["child.bin"]
+
+
+class TestErrorCases:
+    def test_non_string_literal_filename_is_compile_error(self):
+        seq = """\
+name: I32 = 0
+Ref.seqDisp.RUN_ARGS(name, Fw.Wait.WAIT)
+"""
+        fpy.error.file_name = "<test>"
+        body = text_to_ast(seq)
+        result = ast_to_dependencies(body, default_dictionary, ground_binary_dir="/tmp")
+        assert isinstance(result, fpy.error.CompileError)
+        assert "string literal" in str(result)
+
+
+class TestDependMainCLI:
+    """End-to-end CLI tests that write real .fpy files and call depend_main."""
+
+    def test_no_deps_produces_no_output(self, tmp_path, capsys):
+        from fpy.main import depend_main
+
+        fpy_path = tmp_path / "seq.fpy"
+        fpy_path.write_text("")
+        depend_main([str(fpy_path), "-d", default_dictionary, "-g", str(tmp_path)])
+        assert capsys.readouterr().out == ""
+
+    def test_deps_printed_one_per_line(self, tmp_path, capsys):
+        from fpy.main import depend_main
+
+        fpy_path = tmp_path / "seq.fpy"
+        fpy_path.write_text(
+            'Ref.seqDisp.RUN_ARGS("a.bin", Fw.Wait.WAIT)\n'
+            'Ref.seqDisp.RUN_ARGS("b.bin", Fw.Wait.WAIT)\n'
+        )
+        depend_main([str(fpy_path), "-d", default_dictionary, "-g", str(tmp_path)])
+        lines = capsys.readouterr().out.splitlines()
+        assert lines == [str(tmp_path / "a.bin"), str(tmp_path / "b.bin")]
+
+    def test_bins_need_not_exist(self, tmp_path, capsys):
+        from fpy.main import depend_main
+
+        fpy_path = tmp_path / "seq.fpy"
+        fpy_path.write_text('Ref.seqDisp.RUN_ARGS("ghost.bin", Fw.Wait.WAIT)\n')
+        # ghost.bin is never created — should still succeed
+        depend_main([str(fpy_path), "-d", default_dictionary, "-g", str(tmp_path)])
+        assert capsys.readouterr().out.strip() == str(tmp_path / "ghost.bin")
+
+    def test_default_ground_binary_dir_is_input_parent(self, tmp_path, capsys):
+        from fpy.main import depend_main
+
+        fpy_path = tmp_path / "seq.fpy"
+        fpy_path.write_text('Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.WAIT)\n')
+        depend_main([str(fpy_path), "-d", default_dictionary])
+        # Without -g, ground_binary_dir defaults to the input file's directory
+        assert capsys.readouterr().out.strip() == str(tmp_path / "child.bin")

--- a/test/fpy/test_main.py
+++ b/test/fpy/test_main.py
@@ -428,6 +428,97 @@ def test_cmd_main_zmq_addr(monkeypatch, capsys):
     assert sent["addr"] == "tcp://192.168.1.1:50050"
 
 
+# ---------------------------------------------------------------------------
+# depend_main tests
+# ---------------------------------------------------------------------------
+
+
+def test_depend_main_missing_input(tmp_path, capsys):
+    missing = tmp_path / "missing.fpy"
+    dict_path = tmp_path / "dict.json"
+    with pytest.raises(SystemExit) as exc:
+        fpy_main.depend_main([str(missing), "--dictionary", str(dict_path)])
+    assert exc.value.code == 1
+    assert "does not exist" in capsys.readouterr().err
+
+
+def test_depend_main_ground_binary_dir_resolved(monkeypatch, tmp_path):
+    """-g is resolved to an absolute path before being passed to ast_to_dependencies."""
+    fpy_path = tmp_path / "seq.fpy"
+    fpy_path.write_text("content")
+    bin_dir = tmp_path / "bins"
+    bin_dir.mkdir()
+
+    monkeypatch.setattr(fpy_main, "text_to_ast", lambda _text: "AST")
+
+    captured = {}
+
+    def fake_ast_to_dependencies(_body, _dictionary, ground_binary_dir=None):
+        captured["ground_binary_dir"] = ground_binary_dir
+        return []
+
+    monkeypatch.setattr(fpy_main, "ast_to_dependencies", fake_ast_to_dependencies)
+
+    fpy_main.depend_main([str(fpy_path), "-d", "dict.json", "-g", str(bin_dir)])
+
+    assert captured["ground_binary_dir"] == str(bin_dir.resolve())
+
+
+def test_depend_main_default_ground_binary_dir(monkeypatch, tmp_path):
+    """When -g is omitted, ground_binary_dir defaults to the input file's parent."""
+    fpy_path = tmp_path / "seq.fpy"
+    fpy_path.write_text("content")
+
+    monkeypatch.setattr(fpy_main, "text_to_ast", lambda _text: "AST")
+
+    captured = {}
+
+    def fake_ast_to_dependencies(_body, _dictionary, ground_binary_dir=None):
+        captured["ground_binary_dir"] = ground_binary_dir
+        return []
+
+    monkeypatch.setattr(fpy_main, "ast_to_dependencies", fake_ast_to_dependencies)
+
+    fpy_main.depend_main([str(fpy_path), "-d", "dict.json"])
+
+    assert captured["ground_binary_dir"] == str(tmp_path.resolve())
+
+
+def test_depend_main_compile_error_exits(monkeypatch, tmp_path, capsys):
+    """A compile error from ast_to_dependencies is printed to stderr and exits 1."""
+    fpy_path = tmp_path / "seq.fpy"
+    fpy_path.write_text("content")
+
+    monkeypatch.setattr(fpy_main, "text_to_ast", lambda _text: "AST")
+    error = fpy_error.CompileError("bad syntax", None)
+    monkeypatch.setattr(
+        fpy_main, "ast_to_dependencies", lambda _body, _dictionary, ground_binary_dir=None: error
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        fpy_main.depend_main([str(fpy_path), "-d", "dict.json"])
+
+    assert exc.value.code == 1
+    assert "bad syntax" in capsys.readouterr().err
+
+
+def test_depend_main_outputs_deps(monkeypatch, tmp_path, capsys):
+    """Each dependency path is printed to stdout on its own line."""
+    fpy_path = tmp_path / "seq.fpy"
+    fpy_path.write_text("content")
+
+    monkeypatch.setattr(fpy_main, "text_to_ast", lambda _text: "AST")
+    monkeypatch.setattr(
+        fpy_main,
+        "ast_to_dependencies",
+        lambda _body, _dictionary, ground_binary_dir=None: ["/tmp/a.bin", "/tmp/b.bin"],
+    )
+
+    fpy_main.depend_main([str(fpy_path), "-d", "dict.json"])
+
+    assert capsys.readouterr().out == "/tmp/a.bin\n/tmp/b.bin\n"
+
+
 def test_build_command_packet():
     """Command packet has correct wire format: size(4B) + descriptor(2B) + opcode(4B) + args."""
     import struct


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #43  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

* Add the fprime-fpy-depend tool, which extracts the sequence dependencies of a sequence for use in a build system
