### PR TITLE
Fix Dictionary for fprime-gds v4.2.2a1

### DIFF
--- a/src/fpy/dictionary.py
+++ b/src/fpy/dictionary.py
@@ -186,28 +186,16 @@ def _parse_type_definitions(raw_type_defs: list[dict]) -> dict[str, FpyType]:
             json_default=default,
         )
 
-    # Phase 2: Parse aliases (may reference primitives or already-parsed types)
-    remaining_aliases = list(aliases)
-    max_iterations = len(remaining_aliases) + 1
-    for _ in range(max_iterations):
-        still_remaining = []
-        for td in remaining_aliases:
-            name = td["qualifiedName"]
-            underlying = td["underlyingType"]
-            try:
-                resolved = _resolve_type(underlying, type_defs)
-                type_defs[name] = resolved
-            except (AssertionError, KeyError):
-                still_remaining.append(td)
-        if not still_remaining:
-            break
-        remaining_aliases = still_remaining
-    else:
-        unresolved = [td["qualifiedName"] for td in remaining_aliases]
-        assert False, f"Could not resolve alias types: {unresolved}"
-
-    # Phase 3: Parse arrays and structs (may reference each other)
-    remaining = [("array", td) for td in arrays] + [("struct", td) for td in structs]
+    # Phase 2: Parse arrays, aliases, and structs (may all reference each other)
+    # Arrays can reference structs/aliases (e.g., array of ThrusterCommand)
+    # Aliases can reference arrays (e.g., type U256 = U64x4)
+    # Structs can reference arrays/aliases (e.g., member: U256)
+    # So we need to iteratively resolve all three together
+    remaining = (
+        [("array", td) for td in arrays]
+        + [("alias", td) for td in aliases]
+        + [("struct", td) for td in structs]
+    )
     max_iterations = len(remaining) + 1
     for _ in range(max_iterations):
         still_remaining = []
@@ -225,6 +213,10 @@ def _parse_type_definitions(raw_type_defs: list[dict]) -> dict[str, FpyType]:
                         length=length,
                         json_default=default,
                     )
+                elif kind == "alias":
+                    underlying = td["underlyingType"]
+                    resolved = _resolve_type(underlying, type_defs)
+                    type_defs[name] = resolved
                 else:  # struct
                     members_json = td["members"]
                     sorted_members = sorted(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [fprime-gds-v4.2.2a1](https://github.com/nasa/fprime-gds/releases/tag/v4.2.2a1) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Modified array construction in type constructors to unwrap FpyValue objects for numerical arrays, extracting raw Python values instead of storing wrapper objects.                                                        

Unified dictionary parsing Phase 2 to resolve arrays, type aliases, and structs together iteratively, fixing resolution ordering issues for type alias chains (e.g., U256 → U64x4 → array [4] U64).

## Rationale

fprime-gds v4.2.2a1 changes ArrayType.serialize() for numerical arrays to use `struct.pact(array_format, *self._value) `instead of calling `.serialize()` on each element individually.