### PR TITLE
Use seq args buffer size from dict

### DIFF
--- a/src/fpy/compiler.py
+++ b/src/fpy/compiler.py
@@ -241,6 +241,66 @@ def _update_time_base_from_dict(dict_type_name_dict: dict[str, FpyType]) -> None
     dict_type_name_dict["TimeBase"] = TIME_BASE
 
 
+def _update_seq_args_from_dict(dict_type_name_dict: dict[str, FpyType]) -> None:
+    """Update the canonical SEQ_ARGS singleton from the dictionary's Svc.SeqArgs.
+
+    The dictionary's `Svc.SeqArgs` defines the actual buffer capacity for this
+    deployment.  The compiler adopts that length onto the canonical singleton's
+    buffer type so codegen and semantics use the correct size.
+    """
+    assert "Svc.SeqArgs" in dict_type_name_dict, (
+        "Dictionary must contain Svc.SeqArgs type"
+    )
+    dict_seq_args = dict_type_name_dict["Svc.SeqArgs"]
+    assert dict_seq_args.kind == TypeKind.STRUCT, (
+        f"Dictionary Svc.SeqArgs has kind {dict_seq_args.kind}, expected struct"
+    )
+    assert dict_seq_args.members is not None and len(dict_seq_args.members) == 2, (
+        f"Dictionary Svc.SeqArgs must have exactly 2 members, "
+        f"got {dict_seq_args.members}"
+    )
+    size_member, buffer_member = dict_seq_args.members
+    canonical_size_member, canonical_buffer_member = SEQ_ARGS.members
+    assert size_member.name == canonical_size_member.name, (
+        f"Dictionary Svc.SeqArgs first member is '{size_member.name}', "
+        f"expected '{canonical_size_member.name}'"
+    )
+    assert size_member.type == canonical_size_member.type, (
+        f"Dictionary Svc.SeqArgs.{size_member.name} has type {size_member.type}, "
+        f"expected {canonical_size_member.type}"
+    )
+    assert buffer_member.name == canonical_buffer_member.name, (
+        f"Dictionary Svc.SeqArgs second member is '{buffer_member.name}', "
+        f"expected '{canonical_buffer_member.name}'"
+    )
+    dict_buffer_type = buffer_member.type
+    canonical_buffer_type = canonical_buffer_member.type
+    assert dict_buffer_type.kind == TypeKind.ARRAY, (
+        f"Dictionary Svc.SeqArgs.{buffer_member.name} has kind "
+        f"{dict_buffer_type.kind}, expected array"
+    )
+    assert dict_buffer_type.elem_type == canonical_buffer_type.elem_type, (
+        f"Dictionary Svc.SeqArgs.{buffer_member.name} has element type "
+        f"{dict_buffer_type.elem_type}, "
+        f"expected {canonical_buffer_type.elem_type}"
+    )
+    assert dict_buffer_type.length is not None and dict_buffer_type.length > 0, (
+        f"Dictionary Svc.SeqArgs.{buffer_member.name} must have a positive "
+        f"length, got {dict_buffer_type.length}"
+    )
+
+    # Adopt the dictionary's buffer length onto the canonical buffer singleton.
+    canonical_buffer_type.length = dict_buffer_type.length
+    canonical_buffer_type.name = f"Array_U8_{dict_buffer_type.length}"
+
+    # Preserve raw JSON defaults from the dictionary so _populate_type_defaults
+    # can derive the correct-length buffer default.
+    SEQ_ARGS.json_default = dict_seq_args.json_default
+
+    # Replace the dict entry with the canonical singleton.
+    dict_type_name_dict["Svc.SeqArgs"] = SEQ_ARGS
+
+
 def _update_time_context_type_from_dict(
     dict_type_name_dict: dict[str, FpyType],
 ) -> None:
@@ -360,7 +420,7 @@ def _build_global_scopes(dictionary: str) -> tuple:
     _validate_and_replace_type(dict_type_name_dict, "Fw.TimeIntervalValue", TIME_INTERVAL)
     _validate_and_replace_type(dict_type_name_dict, "Fw.CmdResponse", CMD_RESPONSE)
     _validate_and_replace_type(dict_type_name_dict, "Fw.TimeComparison", TIME_COMPARISON)
-    _validate_and_replace_type(dict_type_name_dict, "Svc.SeqArgs", SEQ_ARGS)
+    _update_seq_args_from_dict(dict_type_name_dict)
 
     # Build the full type dict: start from (now-validated) dictionary types,
     # then layer on builtins and internal types.  Later entries win, so

--- a/src/fpy/types.py
+++ b/src/fpy/types.py
@@ -615,12 +615,14 @@ TIME_INTERVAL = FpyType(
     ),
 )
 
-# Default buffer size for Svc.SeqArgs when not derived from dictionary
+# Placeholder buffer size for Svc.SeqArgs; replaced from the dictionary at
+# compile time (see _update_seq_args_from_dict in compiler.py).
 DEFAULT_SEQ_ARGS_BUFFER_SIZE = 255
 
 # The canonical Svc.SeqArgs struct type used for passing arguments to subsequences.
-# This is a struct with a size prefix and a fixed-size byte buffer.
-# FPP struct: { $size: FwSizeType, buffer: [DEFAULT_SEQ_ARGS_BUFFER_SIZE] U8 }
+# The buffer's length and name are updated from the dictionary at compile time,
+# and member_defaults is populated by _populate_type_defaults after the load.
+# FPP struct: { $size: FwSizeType, buffer: [N] U8 }
 _SEQ_ARGS_BUFFER_TYPE = FpyType(
     TypeKind.ARRAY,
     "Array_U8_255",
@@ -634,10 +636,6 @@ SEQ_ARGS = FpyType(
         StructMember("size", U64),
         StructMember("buffer", _SEQ_ARGS_BUFFER_TYPE),
     ),
-    member_defaults={
-        "size": FpyValue(U64, 0),
-        "buffer": FpyValue(_SEQ_ARGS_BUFFER_TYPE, [FpyValue(U8, 0)] * DEFAULT_SEQ_ARGS_BUFFER_SIZE),
-    },
 )
 
 # Internal type (prefixed with $) not directly accessible to users,

--- a/test/fpy/test_seq_calling.py
+++ b/test/fpy/test_seq_calling.py
@@ -7,9 +7,11 @@ All tests accept the ``fprime_test_api`` fixture so they can optionally run
 against a live GDS deployment (``--use-gds``).  When the fixture is ``None``
 (the default) the Python sequencer model is used instead.
 """
+import json
 import tempfile
 from pathlib import Path
 
+import pytest
 
 import fpy.error
 from fpy.bytecode.assembler import serialize_directives
@@ -626,4 +628,102 @@ CdhCore.cmdDisp.CMD_NO_OP()
 """
         compile_seq(fprime_test_api, seq)
 
+
+def _dict_with_seq_args_buffer_size(buffer_size: int, tmpdir: Path) -> str:
+    """Copy the default dictionary into *tmpdir* with Svc.SeqArgs buffer
+    resized to *buffer_size*.  Returns the path to the new dict."""
+    with open(default_dictionary, "r") as f:
+        data = json.load(f)
+    for type_def in data["typeDefinitions"]:
+        if type_def.get("qualifiedName") == "Svc.SeqArgs":
+            type_def["members"]["buffer"]["size"] = buffer_size
+            type_def["default"]["buffer"] = [0] * buffer_size
+            break
+    else:
+        raise AssertionError("Svc.SeqArgs not found in default dictionary")
+    out_path = tmpdir / "ResizedDict.json"
+    out_path.write_text(json.dumps(data))
+    return str(out_path)
+
+
+class TestSeqArgsBufferSizeFromDictionary:
+    """The Svc.SeqArgs buffer length must be taken from the dictionary so that
+    deployments with a non-default capacity compile correctly (issue: the
+    compiler previously hardcoded 255 and crashed on any other size).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_seq_args(self):
+        """Reset the SEQ_ARGS singleton back to the default-dictionary state
+        after each test, since these tests mutate a process-global."""
+        yield
+        _build_global_scopes.cache_clear()
+        load_dictionary.cache_clear()
+        _build_global_scopes(default_dictionary)
+
+    def test_non_default_buffer_size_loads_cleanly(self):
+        """A dictionary with a 1024-byte SeqArgs buffer must compile without
+        crashing — this is the regression for the hardcoded-255 bug."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dict_path = _dict_with_seq_args_buffer_size(1024, Path(tmpdir))
+            _build_global_scopes.cache_clear()
+            load_dictionary.cache_clear()
+            _, _, _, type_defs = _build_global_scopes(dict_path)
+            seq_args = type_defs["Svc.SeqArgs"]
+            assert seq_args.members[1].type.length == 1024
+            assert seq_args.members[1].type.name == "Array_U8_1024"
+
+    def test_oversized_args_use_dictionary_capacity(self, fprime_test_api):
+        """A sequence whose args exceed 255 bytes but fit in a 1024-byte
+        buffer should compile cleanly under a dictionary that defines the
+        larger capacity."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dict_path = _dict_with_seq_args_buffer_size(1024, Path(tmpdir))
+            _build_global_scopes.cache_clear()
+            load_dictionary.cache_clear()
+
+            # 40 U64s = 320 bytes — overflows 255 but fits in 1024.
+            params = ", ".join(f"x{i}: U64" for i in range(40))
+            child_seq = f"sequence({params})\nCdhCore.cmdDisp.CMD_NO_OP()\n"
+            body = text_to_ast(child_seq)
+            assert body is not None
+            result = ast_to_directives(body, dict_path)
+            assert not isinstance(
+                result, (fpy.error.CompileError, fpy.error.BackendError)
+            ), f"Compilation failed:\n{result}"
+
+    def test_args_still_bounded_by_dictionary_capacity(self, fprime_test_api):
+        """Args larger than the dictionary's buffer must still be rejected,
+        and the diagnostic should report the dictionary capacity."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dict_path = _dict_with_seq_args_buffer_size(64, Path(tmpdir))
+            _build_global_scopes.cache_clear()
+            load_dictionary.cache_clear()
+
+            child_path = str(Path(tmpdir).resolve() / "child.bin")
+            # 10 U64s = 80 bytes — overflows the 64-byte buffer.
+            params = ", ".join(f"x{i}: U64" for i in range(10))
+            child_seq = f"sequence({params})\nCdhCore.cmdDisp.CMD_NO_OP()\n"
+            body = text_to_ast(child_seq)
+            assert body is not None
+            result = ast_to_directives(body, dict_path)
+            assert not isinstance(
+                result, (fpy.error.CompileError, fpy.error.BackendError)
+            )
+            directives, arg_types = result
+            arg_specs = [(name, t.name, t.max_size) for name, t in arg_types]
+            data, _ = serialize_directives(directives, arg_specs=arg_specs)
+            Path(child_path).write_bytes(data)
+
+            args = ", ".join("0" for _ in range(10))
+            parent_seq = f'Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, {args})\n'
+            body = text_to_ast(parent_seq)
+            assert body is not None
+            result = ast_to_directives(body, dict_path, ground_binary_dir=tmpdir)
+            assert isinstance(result, fpy.error.CompileError), (
+                f"Expected CompileError, got {type(result).__name__}: {result}"
+            )
+            assert "exceed" in str(result) and "64 bytes" in str(result), (
+                f"Diagnostic should mention the 64-byte capacity, got: {result}"
+            )
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #53  |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

* Read sequence arg buf size from dict instead of requiring that it be 255 bytes
