### PR TITLE
Load Fw* type aliases from dict, fixes before release 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,13 +490,13 @@ When you call a sequence from another sequence, you can provide argument values 
 ```py
 # call the example.bin sequence, in blocking mode, with the argument values 123 and True
 # passing args by name is supported
-Ref.seqDisp.RUN_ARGS("example.bin", Fw.Wait.WAIT, 123, bar=True)
+Ref.seqDisp.RUN_ARGS("example.bin", Svc.BlockState.BLOCK, 123, bar=True)
 ```
 
 To call a sequence from the ground, use the `fprime-fpy-cmd` CLI:
 ```
 # this does the same thing as the previous example
-$ fprime-fpy-cmd 'Ref.seqDisp.RUN_ARGS("example.bin", Fw.Wait.WAIT, 123, bar=True)' -d TopologyDictionary.json
+$ fprime-fpy-cmd 'Ref.seqDisp.RUN_ARGS("example.bin", Svc.BlockState.BLOCK, 123, bar=True)' -d TopologyDictionary.json
 ```
 To use this, you must have a running GDS. See [`fprime-fpy-cmd`](#fprime-fpy-cmd) for more info.
 

--- a/src/fpy/bytecode/assembler.py
+++ b/src/fpy/bytecode/assembler.py
@@ -10,7 +10,7 @@ from lark import Lark, Token, Transformer, v_args
 from lark.tree import Meta
 
 from fpy.bytecode.directives import Directive, StackOpDirective, StackSizeType
-from fpy.types import FpyValue
+from fpy.types import FpyValue, INTERNAL_STRING
 
 from fpy.error import CompileError
 
@@ -290,16 +290,14 @@ def _serialize_arg_specs(arg_specs: list[tuple[str, str, int]]) -> bytes:
     """Serialize arg specs as (arg_name, type_name, size) triples.
 
     Binary format per arg_spec:
-        [1 byte: arg_name UTF-8 length] [N bytes: arg_name]
-        [1 byte: type_name UTF-8 length] [N bytes: type_name]
+        [arg_name as a string]   (FwSizeStoreType-prefixed UTF-8, default 16-bit)
+        [type_name as a string]  (FwSizeStoreType-prefixed UTF-8, default 16-bit)
         [StackSizeType bytes: size]
     """
     result = bytes()
     for arg_name, type_name, size in arg_specs:
-        for name in (arg_name, type_name):
-            encoded = name.encode("utf-8")
-            assert len(encoded) <= 255, f"Name too long: {name}; should have been caught by semantics"
-            result += struct.pack("!B", len(encoded)) + encoded
+        result += FpyValue(INTERNAL_STRING, arg_name).serialize()
+        result += FpyValue(INTERNAL_STRING, type_name).serialize()
         result += FpyValue(StackSizeType, size).serialize()
     return result
 
@@ -309,19 +307,10 @@ def _deserialize_arg_specs(data: bytes, offset: int, count: int) -> tuple[int, l
     Returns (new_offset, list_of_(arg_name, type_name, size)_tuples)."""
     specs = []
     for _ in range(count):
-        # Read arg_name
-        name_len = struct.unpack_from("!B", data, offset)[0]
-        offset += 1
-        arg_name = data[offset:offset + name_len].decode("utf-8")
-        offset += name_len
-        # Read type_name
-        name_len = struct.unpack_from("!B", data, offset)[0]
-        offset += 1
-        type_name = data[offset:offset + name_len].decode("utf-8")
-        offset += name_len
-        # Read size
+        arg_name_val, offset = FpyValue.deserialize(INTERNAL_STRING, data, offset)
+        type_name_val, offset = FpyValue.deserialize(INTERNAL_STRING, data, offset)
         size_val, offset = FpyValue.deserialize(StackSizeType, data, offset)
-        specs.append((arg_name, type_name, size_val.val))
+        specs.append((arg_name_val.val, type_name_val.val, size_val.val))
     return offset, specs
 
 

--- a/src/fpy/bytecode/directives.py
+++ b/src/fpy/bytecode/directives.py
@@ -8,6 +8,8 @@ from typing import ClassVar
 from fpy.types import (
     FpyType,
     FpyValue,
+    TypeKind,
+    FwSizeStoreType,
     U8,
     U16,
     U32,
@@ -32,14 +34,39 @@ from fpy.syntax import (
 # Bytecode-level type aliases (FpyType singletons)
 # ─────────────────────────────────────────────────────────────────────────────
 
-FwSizeType = U64
-FwChanIdType = U32
-FwPrmIdType = U32
-FwOpcodeType = U32
+# User-configurable types
+FwChanIdType = FpyType(TypeKind.U32, "U32")
+FwPrmIdType = FpyType(TypeKind.U32, "U32")
+FwOpcodeType = FpyType(TypeKind.U32, "U32")
+
+
 ArrayIndexType = I64
 StackSizeType = U32
 SignedStackSizeType = I32
 LoopVarType = I64  # same as ArrayIndexType
+
+
+def _update_configurable_type(
+    target: FpyType, type_defs: dict[str, FpyType], name: str
+) -> None:
+    """Update *target* in place to match the dictionary's definition of *name*.
+    """
+    if name not in type_defs:
+        return
+    resolved = type_defs[name]
+    assert resolved.is_primitive, (
+        f"Configurable type {name} must resolve to a primitive, got {resolved}"
+    )
+    target.kind = resolved.kind
+    target.name = resolved.name
+
+
+def update_configurable_types_from_dict(type_defs: dict[str, FpyType]) -> None:
+    """Update the user-configurable Fw* bytecode types in place from the dictionary."""
+    _update_configurable_type(FwChanIdType, type_defs, "FwChanIdType")
+    _update_configurable_type(FwPrmIdType, type_defs, "FwPrmIdType")
+    _update_configurable_type(FwOpcodeType, type_defs, "FwOpcodeType")
+    _update_configurable_type(FwSizeStoreType, type_defs, "FwSizeStoreType")
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/fpy/compiler.py
+++ b/src/fpy/compiler.py
@@ -42,6 +42,7 @@ from fpy.types import (
     DEFAULT_MAX_DIRECTIVE_SIZE,
     DEFAULT_MAX_DIRECTIVES_COUNT,
     SPECIFIC_NUMERIC_TYPES,
+    BLOCK_STATE,
     CHECK_STATE,
     CMD_RESPONSE,
     FLAGS_TYPE,
@@ -447,6 +448,7 @@ def _build_global_scopes(dictionary: str) -> tuple:
     _validate_and_replace_type(dict_type_name_dict, "Fw.TimeIntervalValue", TIME_INTERVAL)
     _validate_and_replace_type(dict_type_name_dict, "Fw.CmdResponse", CMD_RESPONSE)
     _validate_and_replace_type(dict_type_name_dict, "Fw.TimeComparison", TIME_COMPARISON)
+    _validate_and_replace_type(dict_type_name_dict, "Svc.BlockState", BLOCK_STATE)
     _update_seq_args_from_dict(dict_type_name_dict)
 
     # Build the full type dict: start from (now-validated) dictionary types,
@@ -484,11 +486,11 @@ def _build_global_scopes(dictionary: str) -> tuple:
     for name, cmd in cmd_name_dict.items():
         args = [(arg_name, arg_type, None) for arg_name, _, arg_type in cmd.arguments]
         # Detect sequence-run commands by matching the 3-arg signature:
-        # (fileName: string, block: <any enum>, args: Svc.SeqArgs)
+        # (fileName: string, block: Svc.BlockState, args: Svc.SeqArgs)
         if (
             len(args) == 3
             and args[0][1].is_string
-            and args[1][1].kind == TypeKind.ENUM
+            and args[1][1].name == "Svc.BlockState"
             and args[2][1].name == "Svc.SeqArgs"
         ):
             # Strip the SeqArgs param; user provides varargs instead

--- a/src/fpy/compiler.py
+++ b/src/fpy/compiler.py
@@ -3,7 +3,7 @@ import sys
 from functools import lru_cache
 from pathlib import Path
 from lark import Lark, LarkError
-from fpy.bytecode.directives import Directive
+from fpy.bytecode.directives import Directive, update_configurable_types_from_dict
 from fpy.codegen import (
     CalculateFrameSizes,
     CollectUsedFunctions,
@@ -435,6 +435,10 @@ def _build_global_scopes(dictionary: str) -> tuple:
     ch_name_dict = d["ch_name_dict"]
     prm_name_dict = d["prm_name_dict"]
     dict_type_name_dict = d["type_defs"]
+
+    # Update user-configurable bytecode types (FwChanIdType, FwOpcodeType,
+    # FwPrmIdType, FwSizeStoreType) from the dictionary before they are used.
+    update_configurable_types_from_dict(dict_type_name_dict)
 
     # Validate required dictionary types
     _update_time_base_from_dict(dict_type_name_dict)

--- a/src/fpy/model.py
+++ b/src/fpy/model.py
@@ -568,7 +568,7 @@ class FpySequencerModel:
         from pathlib import Path
         from fpy.bytecode.assembler import deserialize_directives, resolve_arg_specs
 
-        # Parse command args: fileName (string), blockState (enum), seqArgs (struct)
+        # Parse command args: fileName (string), blockState (Svc.BlockState), seqArgs (struct)
         # First: read the command definition to know arg sizes
         cmd = self.cmd_dict[opcode]
         offset = 0

--- a/src/fpy/test_helpers.py
+++ b/src/fpy/test_helpers.py
@@ -88,9 +88,9 @@ def run_seq(
         seq_path = _write_seq_to_tmpfile(directives, arg_name_types)
         if args:
             seq_args = _build_seq_args_json(args)
-            fprime_test_api.send_and_assert_command("Ref.seqDisp.RUN_ARGS", [seq_path, "WAIT", seq_args], timeout=timeout_s)
+            fprime_test_api.send_and_assert_command("Ref.seqDisp.RUN_ARGS", [seq_path, "BLOCK", seq_args], timeout=timeout_s)
         else:
-            fprime_test_api.send_and_assert_command("Ref.seqDisp.RUN", [seq_path, "WAIT"], timeout=timeout_s)
+            fprime_test_api.send_and_assert_command("Ref.seqDisp.RUN", [seq_path, "BLOCK"], timeout=timeout_s)
         return
 
     d = load_dictionary(default_dictionary)
@@ -225,14 +225,14 @@ def assert_run_failure(
             seq_args = _build_seq_args_json(args_bytes)
             fprime_test_api.send_and_assert_event(
                 "Ref.seqDisp.RUN_ARGS",
-                [seq_path, "WAIT", seq_args],
+                [seq_path, "BLOCK", seq_args],
                 events="CdhCore.cmdDisp.OpCodeError",
                 timeout=4,
             )
         else:
             fprime_test_api.send_and_assert_event(
                 "Ref.seqDisp.RUN",
-                [seq_path, "WAIT"],
+                [seq_path, "BLOCK"],
                 events="CdhCore.cmdDisp.OpCodeError",
                 timeout=4,
             )

--- a/src/fpy/types.py
+++ b/src/fpy/types.py
@@ -611,6 +611,16 @@ TIME_COMPARISON = FpyType(
     rep_type=I32,
 )
 
+# The canonical Svc.BlockState enum type. Both the seq dispatcher's RUN_ARGS and
+# the fpy sequencer's RUN command take their blocking arg as this type, so the
+# compiler can match sequence-run commands by this exact type.
+BLOCK_STATE = FpyType(
+    TypeKind.ENUM,
+    "Svc.BlockState",
+    enum_dict={"BLOCK": 0, "NO_BLOCK": 1},
+    rep_type=U8,
+)
+
 # The canonical Fw.TimeIntervalValue struct type
 TIME_INTERVAL = FpyType(
     TypeKind.STRUCT,

--- a/src/fpy/types.py
+++ b/src/fpy/types.py
@@ -284,7 +284,7 @@ class FpyType:
             assert (
                 self.max_length is not None
             ), "Cannot compute size of arbitrary-length string"
-            return 2 + self.max_length
+            return FwSizeStoreType.max_size + self.max_length
         if self.kind == TypeKind.ENUM:
             return self.rep_type.max_size
         if self.kind == TypeKind.STRUCT:
@@ -339,6 +339,10 @@ I64 = FpyType(TypeKind.I64, "I64")
 F32 = FpyType(TypeKind.F32, "F32")
 F64 = FpyType(TypeKind.F64, "F64")
 BOOL = FpyType(TypeKind.BOOL, "bool")
+
+# distinct singleton so that the in-place update 
+# is visible everywhere the object is referenced.
+FwSizeStoreType = FpyType(TypeKind.U16, "U16")
 
 # The canonical TimeBase enum type — default placeholder.
 # The full set of enum constants and representation type are loaded from the
@@ -449,7 +453,7 @@ class FpyValue:
                     raise ValueError(
                         f"String too long: {len(encoded)} > {self.type.max_length}"
                     )
-            return struct.pack(">H", len(encoded)) + encoded
+            return FpyValue(FwSizeStoreType, len(encoded)).serialize() + encoded
 
         if kind == TypeKind.ENUM:
             val = self.val
@@ -494,8 +498,10 @@ class FpyValue:
             return FpyValue(typ, raw), offset + size
 
         if kind in (TypeKind.STRING, TypeKind.INTERNAL_STRING):
-            str_len = struct.unpack_from(">H", data, offset)[0]
-            offset += 2
+            size_val, offset = FpyValue.deserialize(
+                FwSizeStoreType, data, offset
+            )
+            str_len = size_val.val
             s = data[offset : offset + str_len].decode("utf-8")
             offset += str_len
             return FpyValue(typ, s), offset

--- a/test/fpy/RefTopologyDictionary.json
+++ b/test/fpy/RefTopologyDictionary.json
@@ -1,8 +1,8 @@
 {
   "metadata" : {
     "deploymentName" : "Ref.Ref",
-    "projectVersion" : "0a409b9-dirty",
-    "frameworkVersion" : "v4.2.0-19-gce1a60a8b-dirty",
+    "projectVersion" : "860cb72",
+    "frameworkVersion" : "v4.2.0-131-g5fa74db1c",
     "libraryVersions" : [
     ],
     "dictionarySpecVersion" : "1.0.0"
@@ -24,19 +24,42 @@
       "annotation" : "Array of queue depths for Fw::Buffer types"
     },
     {
-      "kind" : "alias",
-      "qualifiedName" : "FwIndexType",
-      "type" : {
-        "name" : "PlatformIndexType",
-        "kind" : "qualifiedIdentifier"
+      "kind" : "enum",
+      "qualifiedName" : "Svc.PrmDb.Merge",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
       },
-      "underlyingType" : {
-        "name" : "I16",
+      "enumeratedConstants" : [
+        {
+          "name" : "MERGE",
+          "value" : 0
+        },
+        {
+          "name" : "RESET",
+          "value" : 1
+        }
+      ],
+      "default" : "Svc.PrmDb.Merge.MERGE"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "FwTlmPacketizeIdType",
+      "type" : {
+        "name" : "U16",
         "kind" : "integer",
         "size" : 16,
-        "signed" : true
+        "signed" : false
       },
-      "annotation" : "The type of smaller indices internal to the software, used\nfor array indices, e.g., port indices. Must be signed."
+      "underlyingType" : {
+        "name" : "U16",
+        "kind" : "integer",
+        "size" : 16,
+        "signed" : false
+      },
+      "annotation" : "The type of a telemetry packet identifier"
     },
     {
       "kind" : "alias",
@@ -430,6 +453,39 @@
     },
     {
       "kind" : "enum",
+      "qualifiedName" : "Svc.Ccsds.EppLengthOfLength",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "Zero",
+          "value" : 0,
+          "annotation" : "0b00 - Single Byte Idle Packet"
+        },
+        {
+          "name" : "One",
+          "value" : 1,
+          "annotation" : "0b01 - Two Byte Header"
+        },
+        {
+          "name" : "Two",
+          "value" : 2,
+          "annotation" : "0b10 - Four Byte Header"
+        },
+        {
+          "name" : "Four",
+          "value" : 3,
+          "annotation" : "0b11 - Eight Byte Header"
+        }
+      ],
+      "default" : "Svc.Ccsds.EppLengthOfLength.Zero"
+    },
+    {
+      "kind" : "enum",
       "qualifiedName" : "Ref.SignalType",
       "representationType" : {
         "name" : "I32",
@@ -544,6 +600,35 @@
         }
       ],
       "default" : "Svc.PrmDb.PrmLoadAction.SET_PARAMETER"
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "Svc.Ccsds.EppProtocolId",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "Idle",
+          "value" : 0,
+          "annotation" : "0b000 - Encapsulation Idle Packet"
+        },
+        {
+          "name" : "Extended",
+          "value" : 6,
+          "annotation" : "0b110 - Extended Protocol ID Field Driven"
+        },
+        {
+          "name" : "MissionSpecific",
+          "value" : 7,
+          "annotation" : "Mission-specific"
+        }
+      ],
+      "default" : "Svc.Ccsds.EppProtocolId.MissionSpecific",
+      "annotation" : "Protocol IDs for EPP encapsulation packets per CCSDS 133.1-B-3 Section 4.1.2.3.3"
     },
     {
       "kind" : "alias",
@@ -926,50 +1011,6 @@
       "annotation" : "Send file status enum"
     },
     {
-      "kind" : "enum",
-      "qualifiedName" : "Svc.PrmDb.Merge",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "MERGE",
-          "value" : 0
-        },
-        {
-          "name" : "RESET",
-          "value" : 1
-        }
-      ],
-      "default" : "Svc.PrmDb.Merge.MERGE"
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "Svc.FprimeRouter.AllocationReason",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "FILE_UPLINK",
-          "value" : 0,
-          "annotation" : "Buffer allocation for file uplink"
-        },
-        {
-          "name" : "USER_BUFFER",
-          "value" : 1,
-          "annotation" : "Buffer allocation for user handled buffer"
-        }
-      ],
-      "default" : "Svc.FprimeRouter.AllocationReason.FILE_UPLINK"
-    },
-    {
       "kind" : "alias",
       "qualifiedName" : "FwTimeContextStoreType",
       "type" : {
@@ -1224,27 +1265,6 @@
       "annotation" : "The type of a data product identifier"
     },
     {
-      "kind" : "enum",
-      "qualifiedName" : "Svc.FpySequencer.BlockState",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "BLOCK",
-          "value" : 0
-        },
-        {
-          "name" : "NO_BLOCK",
-          "value" : 1
-        }
-      ],
-      "default" : "Svc.FpySequencer.BlockState.BLOCK"
-    },
-    {
       "kind" : "struct",
       "qualifiedName" : "Ref.SignalPair",
       "members" : {
@@ -1387,6 +1407,28 @@
       "annotation" : "Enum representing a command response"
     },
     {
+      "kind" : "enum",
+      "qualifiedName" : "Svc.BlockState",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "BLOCK",
+          "value" : 0
+        },
+        {
+          "name" : "NO_BLOCK",
+          "value" : 1
+        }
+      ],
+      "default" : "Svc.BlockState.BLOCK",
+      "annotation" : "Sequencer blocking state"
+    },
+    {
       "kind" : "alias",
       "qualifiedName" : "FwIdType",
       "type" : {
@@ -1421,121 +1463,19 @@
       "annotation" : "The type used to serialize a C++ enumeration constant\nFPP enumerations are serialized according to their representation types"
     },
     {
-      "kind" : "array",
-      "qualifiedName" : "Ref.ManyChoices",
-      "size" : 2,
-      "elementType" : {
-        "name" : "Ref.Choice",
+      "kind" : "alias",
+      "qualifiedName" : "FwIndexType",
+      "type" : {
+        "name" : "PlatformIndexType",
         "kind" : "qualifiedIdentifier"
       },
-      "default" : [
-        "Ref.Choice.ONE",
-        "Ref.Choice.ONE"
-      ],
-      "annotation" : "Enumeration array"
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "Svc.EventManager.Enabled",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "ENABLED",
-          "value" : 0,
-          "annotation" : "Enabled state"
-        },
-        {
-          "name" : "DISABLED",
-          "value" : 1,
-          "annotation" : "Disabled state"
-        }
-      ],
-      "default" : "Svc.EventManager.Enabled.ENABLED",
-      "annotation" : "Enabled and disabled state"
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "Ref.DpDemo.I32Alias",
-      "type" : {
-        "name" : "I32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : true
-      },
       "underlyingType" : {
-        "name" : "I32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : true
-      }
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "Fw.DpCfg.ProcType",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "PROC_TYPE_ZERO",
-          "value" : 1,
-          "annotation" : "Processing type 0"
-        },
-        {
-          "name" : "PROC_TYPE_ONE",
-          "value" : 2,
-          "annotation" : "Processing type 1"
-        },
-        {
-          "name" : "PROC_TYPE_TWO",
-          "value" : 4,
-          "annotation" : "Processing type 2"
-        }
-      ],
-      "default" : "Fw.DpCfg.ProcType.PROC_TYPE_ZERO",
-      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "Svc.Fpy.StackSizeType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "annotation" : "the type which everything referencing a size or offset on the stack is represented in"
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwTlmPacketizeIdType",
-      "type" : {
-        "name" : "U16",
+        "name" : "I16",
         "kind" : "integer",
         "size" : 16,
-        "signed" : false
+        "signed" : true
       },
-      "underlyingType" : {
-        "name" : "U16",
-        "kind" : "integer",
-        "size" : 16,
-        "signed" : false
-      },
-      "annotation" : "The type of a telemetry packet identifier"
+      "annotation" : "The type of smaller indices internal to the software, used\nfor array indices, e.g., port indices. Must be signed."
     },
     {
       "kind" : "enum",
@@ -1850,9 +1790,117 @@
         {
           "name" : "POP_EVENT",
           "value" : 75
+        },
+        {
+          "name" : "SET_SEED",
+          "value" : 76
+        },
+        {
+          "name" : "PUSH_RAND",
+          "value" : 77
         }
       ],
       "default" : "Svc.Fpy.DirectiveId.INVALID"
+    },
+    {
+      "kind" : "array",
+      "qualifiedName" : "Ref.ManyChoices",
+      "size" : 2,
+      "elementType" : {
+        "name" : "Ref.Choice",
+        "kind" : "qualifiedIdentifier"
+      },
+      "default" : [
+        "Ref.Choice.ONE",
+        "Ref.Choice.ONE"
+      ],
+      "annotation" : "Enumeration array"
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "Svc.EventManager.Enabled",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "ENABLED",
+          "value" : 0,
+          "annotation" : "Enabled state"
+        },
+        {
+          "name" : "DISABLED",
+          "value" : 1,
+          "annotation" : "Disabled state"
+        }
+      ],
+      "default" : "Svc.EventManager.Enabled.ENABLED",
+      "annotation" : "Enabled and disabled state"
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "Ref.DpDemo.I32Alias",
+      "type" : {
+        "name" : "I32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : true
+      },
+      "underlyingType" : {
+        "name" : "I32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : true
+      }
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "Fw.DpCfg.ProcType",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "PROC_TYPE_ZERO",
+          "value" : 1,
+          "annotation" : "Processing type 0"
+        },
+        {
+          "name" : "PROC_TYPE_ONE",
+          "value" : 2,
+          "annotation" : "Processing type 1"
+        },
+        {
+          "name" : "PROC_TYPE_TWO",
+          "value" : 4,
+          "annotation" : "Processing type 2"
+        }
+      ],
+      "default" : "Fw.DpCfg.ProcType.PROC_TYPE_ZERO",
+      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+    },
+    {
+      "kind" : "alias",
+      "qualifiedName" : "Svc.Fpy.StackSizeType",
+      "type" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "underlyingType" : {
+        "name" : "U32",
+        "kind" : "integer",
+        "size" : 32,
+        "signed" : false
+      },
+      "annotation" : "the type which everything referencing a size or offset on the stack is represented in"
     },
     {
       "kind" : "alias",
@@ -2199,6 +2247,35 @@
         }
       ],
       "default" : "Svc.SystemResourceEnabled.DISABLED"
+    },
+    {
+      "kind" : "enum",
+      "qualifiedName" : "ComCfg.Pvn",
+      "representationType" : {
+        "name" : "U8",
+        "kind" : "integer",
+        "size" : 8,
+        "signed" : false
+      },
+      "enumeratedConstants" : [
+        {
+          "name" : "SPACE_PACKET_PROTOCOL",
+          "value" : 0,
+          "annotation" : "Fully Featured CCSDS Space Packet Protocol"
+        },
+        {
+          "name" : "ENCAPSULATION_PACKET_PROTOCOL",
+          "value" : 7,
+          "annotation" : "Bare-bones CCSDS Encapsulation Packet Protocol"
+        },
+        {
+          "name" : "INVALID_UNINITIALIZED",
+          "value" : 8,
+          "annotation" : "Anything equal or higher value is invalid and should not be used"
+        }
+      ],
+      "default" : "ComCfg.Pvn.INVALID_UNINITIALIZED",
+      "annotation" : "Packet Version Numbers are 3 bits with only 2 currently valid values"
     },
     {
       "kind" : "array",
@@ -3322,6 +3399,17 @@
     },
     {
       "kind" : "constant",
+      "qualifiedName" : "Svc.Fpy.DEFAULT_SEQ_BASE_DIR",
+      "type" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 256
+      },
+      "value" : "",
+      "annotation" : "the default value of the SEQ_BASE_DIR parameter. suffixed to\nthe input sequence file path before resolution occurs following\nthe rules of Os::File::open. trailing slash optional"
+    },
+    {
+      "kind" : "constant",
       "qualifiedName" : "ComQueueComPorts",
       "type" : {
         "name" : "U64",
@@ -3358,6 +3446,18 @@
     },
     {
       "kind" : "constant",
+      "qualifiedName" : "FW_FIXED_LENGTH_STRING_SIZE",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 256,
+      "annotation" : "Configuration for Fw::String\nNote: FPrimeBasicTypes.hpp needs to be updated to sync enum"
+    },
+    {
+      "kind" : "constant",
       "qualifiedName" : "FW_SERIALIZE_FALSE_VALUE",
       "type" : {
         "name" : "U64",
@@ -3391,6 +3491,18 @@
       },
       "value" : 512,
       "annotation" : "Specifies the size of the buffer that contains a communications packet"
+    },
+    {
+      "kind" : "constant",
+      "qualifiedName" : "AssertFatalAdapterEventFileSize",
+      "type" : {
+        "name" : "U64",
+        "kind" : "integer",
+        "size" : 64,
+        "signed" : false
+      },
+      "value" : 240,
+      "annotation" : "The size of a file name in an AssertFatalAdapter event (leading-truncation)\nNote: File names in assertion failures are also truncated by\nthe constants FwAssertTextSize (in this file) and FW_LOG_STRING_MAX_SIZE (set\nin FW_LOG_STRING_MAX_SIZE)\nSet much smaller than FwAssertTextSize so there's space for time stamp/assert\narguments in log message"
     },
     {
       "kind" : "constant",
@@ -3439,30 +3551,6 @@
       },
       "value" : 2048,
       "annotation" : "the maximum number of bytes in a directive"
-    },
-    {
-      "kind" : "constant",
-      "qualifiedName" : "FW_FIXED_LENGTH_STRING_SIZE",
-      "type" : {
-        "name" : "U64",
-        "kind" : "integer",
-        "size" : 64,
-        "signed" : false
-      },
-      "value" : 256,
-      "annotation" : "Configuration for Fw::String\nNote: FPrimeBasicTypes.hpp needs to be updated to sync enum"
-    },
-    {
-      "kind" : "constant",
-      "qualifiedName" : "AssertFatalAdapterEventFileSize",
-      "type" : {
-        "name" : "U64",
-        "kind" : "integer",
-        "size" : 64,
-        "signed" : false
-      },
-      "value" : 240,
-      "annotation" : "The size of a file name in an AssertFatalAdapter event\nNote: File names in assertion failures are also truncated by\nthe constants FW_ASSERT_TEXT_SIZE and FW_LOG_STRING_MAX_SIZE, set\nin FpConfig.h."
     },
     {
       "kind" : "constant",
@@ -4135,35 +4223,6 @@
       "annotation" : "Remove a file"
     },
     {
-      "name" : "FileHandling.fileManager.ShellCommand",
-      "commandKind" : "async",
-      "opcode" : 83894276,
-      "formalParams" : [
-        {
-          "name" : "command",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false,
-          "annotation" : "The shell command string"
-        },
-        {
-          "name" : "logFileName",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 240
-          },
-          "ref" : false,
-          "annotation" : "The name of the log file"
-        }
-      ],
-      "queueFullBehavior" : "assert",
-      "annotation" : "Perform a Linux shell command and write the output to a log file."
-    },
-    {
       "name" : "FileHandling.fileManager.AppendFile",
       "commandKind" : "async",
       "opcode" : 83894277,
@@ -4246,7 +4305,7 @@
         }
       ],
       "queueFullBehavior" : "assert",
-      "annotation" : "List the contents of a directory"
+      "annotation" : "Calculate the CRC of a file"
     },
     {
       "name" : "FileHandling.prmDb.PRM_SAVE_FILE",
@@ -4714,7 +4773,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Svc.FpySequencer.BlockState",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -4743,7 +4802,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Svc.FpySequencer.BlockState",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -4819,7 +4878,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Svc.FpySequencer.BlockState",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -4957,6 +5016,31 @@
       "annotation" : "the number of seconds to wait before giving up\non a directive or command. if <= 0 or greater than U32 max, never time out.\naccuracy of this timeout is determined by the rate group driving this\ncomponent. it will be rounded up"
     },
     {
+      "name" : "Ref.cmdSeq0.SEQ_BASE_DIR_PRM_SET",
+      "commandKind" : "set",
+      "opcode" : 268460046,
+      "formalParams" : [
+        {
+          "name" : "val",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 240
+          },
+          "ref" : false
+        }
+      ],
+      "annotation" : "the base directory relative to which sequence file paths are resolved.\na '/' separator is always inserted between this base dir and the input\nsequence file path before resolution occurs following the rules of\nOs::File::open."
+    },
+    {
+      "name" : "Ref.cmdSeq0.SEQ_BASE_DIR_PRM_SAVE",
+      "commandKind" : "save",
+      "opcode" : 268460047,
+      "formalParams" : [
+      ],
+      "annotation" : "the base directory relative to which sequence file paths are resolved.\na '/' separator is always inserted between this base dir and the input\nsequence file path before resolution occurs following the rules of\nOs::File::open."
+    },
+    {
       "name" : "Ref.cmdSeq1.RUN",
       "commandKind" : "async",
       "opcode" : 268464128,
@@ -4974,7 +5058,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Svc.FpySequencer.BlockState",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -5003,7 +5087,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Svc.FpySequencer.BlockState",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -5079,7 +5163,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Svc.FpySequencer.BlockState",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -5217,6 +5301,31 @@
       "annotation" : "the number of seconds to wait before giving up\non a directive or command. if <= 0 or greater than U32 max, never time out.\naccuracy of this timeout is determined by the rate group driving this\ncomponent. it will be rounded up"
     },
     {
+      "name" : "Ref.cmdSeq1.SEQ_BASE_DIR_PRM_SET",
+      "commandKind" : "set",
+      "opcode" : 268464142,
+      "formalParams" : [
+        {
+          "name" : "val",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 240
+          },
+          "ref" : false
+        }
+      ],
+      "annotation" : "the base directory relative to which sequence file paths are resolved.\na '/' separator is always inserted between this base dir and the input\nsequence file path before resolution occurs following the rules of\nOs::File::open."
+    },
+    {
+      "name" : "Ref.cmdSeq1.SEQ_BASE_DIR_PRM_SAVE",
+      "commandKind" : "save",
+      "opcode" : 268464143,
+      "formalParams" : [
+      ],
+      "annotation" : "the base directory relative to which sequence file paths are resolved.\na '/' separator is always inserted between this base dir and the input\nsequence file path before resolution occurs following the rules of\nOs::File::open."
+    },
+    {
       "name" : "Ref.seqDisp.RUN",
       "commandKind" : "async",
       "opcode" : 268468224,
@@ -5234,7 +5343,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Fw.Wait",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -5262,7 +5371,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Fw.Wait",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -5308,7 +5417,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Svc.FpySequencer.BlockState",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -5337,7 +5446,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Svc.FpySequencer.BlockState",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -5413,7 +5522,7 @@
         {
           "name" : "block",
           "type" : {
-            "name" : "Svc.FpySequencer.BlockState",
+            "name" : "Svc.BlockState",
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false,
@@ -5549,6 +5658,31 @@
       "formalParams" : [
       ],
       "annotation" : "the number of seconds to wait before giving up\non a directive or command. if <= 0 or greater than U32 max, never time out.\naccuracy of this timeout is determined by the rate group driving this\ncomponent. it will be rounded up"
+    },
+    {
+      "name" : "Ref.cmdSeq2.SEQ_BASE_DIR_PRM_SET",
+      "commandKind" : "set",
+      "opcode" : 268472334,
+      "formalParams" : [
+        {
+          "name" : "val",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 240
+          },
+          "ref" : false
+        }
+      ],
+      "annotation" : "the base directory relative to which sequence file paths are resolved.\na '/' separator is always inserted between this base dir and the input\nsequence file path before resolution occurs following the rules of\nOs::File::open."
+    },
+    {
+      "name" : "Ref.cmdSeq2.SEQ_BASE_DIR_PRM_SAVE",
+      "commandKind" : "save",
+      "opcode" : 268472335,
+      "formalParams" : [
+      ],
+      "annotation" : "the base directory relative to which sequence file paths are resolved.\na '/' separator is always inserted between this base dir and the input\nsequence file path before resolution occurs following the rules of\nOs::File::open."
     },
     {
       "name" : "Ref.sendBuffComp.SB_START_PKTS",
@@ -6364,6 +6498,17 @@
       "annotation" : "the number of seconds to wait before giving up\non a directive or command. if <= 0 or greater than U32 max, never time out.\naccuracy of this timeout is determined by the rate group driving this\ncomponent. it will be rounded up"
     },
     {
+      "name" : "Ref.cmdSeq0.SEQ_BASE_DIR",
+      "type" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 240
+      },
+      "id" : 268460033,
+      "default" : "",
+      "annotation" : "the base directory relative to which sequence file paths are resolved.\na '/' separator is always inserted between this base dir and the input\nsequence file path before resolution occurs following the rules of\nOs::File::open."
+    },
+    {
       "name" : "Ref.cmdSeq1.STATEMENT_TIMEOUT_SECS",
       "type" : {
         "name" : "F32",
@@ -6375,6 +6520,17 @@
       "annotation" : "the number of seconds to wait before giving up\non a directive or command. if <= 0 or greater than U32 max, never time out.\naccuracy of this timeout is determined by the rate group driving this\ncomponent. it will be rounded up"
     },
     {
+      "name" : "Ref.cmdSeq1.SEQ_BASE_DIR",
+      "type" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 240
+      },
+      "id" : 268464129,
+      "default" : "",
+      "annotation" : "the base directory relative to which sequence file paths are resolved.\na '/' separator is always inserted between this base dir and the input\nsequence file path before resolution occurs following the rules of\nOs::File::open."
+    },
+    {
       "name" : "Ref.cmdSeq2.STATEMENT_TIMEOUT_SECS",
       "type" : {
         "name" : "F32",
@@ -6384,6 +6540,17 @@
       "id" : 268472320,
       "default" : 0.0,
       "annotation" : "the number of seconds to wait before giving up\non a directive or command. if <= 0 or greater than U32 max, never time out.\naccuracy of this timeout is determined by the rate group driving this\ncomponent. it will be rounded up"
+    },
+    {
+      "name" : "Ref.cmdSeq2.SEQ_BASE_DIR",
+      "type" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 240
+      },
+      "id" : 268472321,
+      "default" : "",
+      "annotation" : "the base directory relative to which sequence file paths are resolved.\na '/' separator is always inserted between this base dir and the input\nsequence file path before resolution occurs following the rules of\nOs::File::open."
     },
     {
       "name" : "Ref.sendBuffComp.parameter3",
@@ -7745,6 +7912,37 @@
       "annotation" : "An unexpected assert happened"
     },
     {
+      "name" : "CdhCore.tlmSend.TlmChanEpochProcessingCapReached",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "numDeferred",
+          "type" : {
+            "name" : "U32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : false
+          },
+          "ref" : false,
+          "annotation" : "Entries skipped (dropped) this invocation"
+        },
+        {
+          "name" : "numTimesDeferredCountReached",
+          "type" : {
+            "name" : "U32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : false
+          },
+          "ref" : false,
+          "annotation" : "Cumulative invocations where cap was reached"
+        }
+      ],
+      "id" : 16801792,
+      "format" : "TlmChan epoch processing cap reached: {} entries deferred (cumulative: {})",
+      "annotation" : "Epoch Processing cap reached; one or more telemetry entries were deferred this cycle"
+    },
+    {
       "name" : "ComCcsds.comQueue.QueueOverflow",
       "severity" : "WARNING_HI",
       "formalParams" : [
@@ -7834,6 +8032,15 @@
       "annotation" : "A frame was detected whose size exceeds the internal accumulation buffer\ncapacity. No choice but to drop the frame."
     },
     {
+      "name" : "ComCcsds.frameAccumulator.FrameDetectionValidFrameDropped",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+      ],
+      "id" : 33558530,
+      "format" : "A valid frame was detected but dropped",
+      "annotation" : "A frame was detected but dropped because there was no buffer to hold it"
+    },
+    {
       "name" : "ComCcsds.commsBufferManager.NoBuffsAvailable",
       "severity" : "WARNING_HI",
       "formalParams" : [
@@ -7907,23 +8114,6 @@
       "id" : 33566721,
       "format" : "Deserializing packet type failed with status {}",
       "annotation" : "An error occurred while deserializing a packet"
-    },
-    {
-      "name" : "ComCcsds.fprimeRouter.AllocationError",
-      "severity" : "WARNING_HI",
-      "formalParams" : [
-        {
-          "name" : "reason",
-          "type" : {
-            "name" : "Svc.FprimeRouter.AllocationReason",
-            "kind" : "qualifiedIdentifier"
-          },
-          "ref" : false
-        }
-      ],
-      "id" : 33566722,
-      "format" : "Buffer allocation for {} failed",
-      "annotation" : "An allocation error occurred"
     },
     {
       "name" : "ComCcsds.tcDeframer.InvalidPacket",
@@ -8064,10 +8254,8 @@
         {
           "name" : "transmitted",
           "type" : {
-            "name" : "U16",
-            "kind" : "integer",
-            "size" : 16,
-            "signed" : false
+            "name" : "FwSizeType",
+            "kind" : "qualifiedIdentifier"
           },
           "ref" : false
         },
@@ -9024,6 +9212,68 @@
       ],
       "id" : 67108910,
       "format" : "Cannot Transmit a Catalog before Building"
+    },
+    {
+      "name" : "DataProducts.dpCat.InvalidFileName",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "file",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 240
+          },
+          "ref" : false,
+          "annotation" : "The invalid file"
+        },
+        {
+          "name" : "expected",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 240
+          },
+          "ref" : false,
+          "annotation" : "The expected canonical file"
+        }
+      ],
+      "id" : 67108911,
+      "format" : "Invalid DP file name {}. Expected {}",
+      "annotation" : "DP file name does not match the file's header metadata",
+      "throttle" : {
+        "count" : 10,
+        "every" : null
+      }
+    },
+    {
+      "name" : "DataProducts.dpCat.FileCorruptedDataError",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "file",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 240
+          },
+          "ref" : false,
+          "annotation" : "The file"
+        },
+        {
+          "name" : "stat",
+          "type" : {
+            "name" : "I32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : true
+          },
+          "ref" : false
+        }
+      ],
+      "id" : 67108912,
+      "format" : "DP file {} contains malformed data (status {})",
+      "annotation" : "The file contained malformed or invalid data during deserialization"
     },
     {
       "name" : "DataProducts.dpMgr.BufferAllocationFailed",
@@ -10091,36 +10341,6 @@
       "annotation" : "An error occurred while attempting to remove a file"
     },
     {
-      "name" : "FileHandling.fileManager.ShellCommandFailed",
-      "severity" : "WARNING_HI",
-      "formalParams" : [
-        {
-          "name" : "command",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false,
-          "annotation" : "The command string"
-        },
-        {
-          "name" : "status",
-          "type" : {
-            "name" : "U32",
-            "kind" : "integer",
-            "size" : 32,
-            "signed" : false
-          },
-          "ref" : false,
-          "annotation" : "The status code"
-        }
-      ],
-      "id" : 83894276,
-      "format" : "Shell command {} failed with status {}",
-      "annotation" : "The File System component executed a shell command that returned status non-zero"
-    },
-    {
       "name" : "FileHandling.fileManager.AppendFileFailed",
       "severity" : "WARNING_HI",
       "formalParams" : [
@@ -10188,25 +10408,6 @@
       "id" : 83894278,
       "format" : "Appended {} to the end of {}",
       "annotation" : "The File System component appended 2 files without error"
-    },
-    {
-      "name" : "FileHandling.fileManager.ShellCommandSucceeded",
-      "severity" : "ACTIVITY_HI",
-      "formalParams" : [
-        {
-          "name" : "command",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 240
-          },
-          "ref" : false,
-          "annotation" : "The command string"
-        }
-      ],
-      "id" : 83894279,
-      "format" : "Shell command {} succeeded",
-      "annotation" : "The File System component executed a shell command that returned status zero"
     },
     {
       "name" : "FileHandling.fileManager.CreateDirectorySucceeded",
@@ -10322,25 +10523,6 @@
       "id" : 83894284,
       "format" : "Appending file {} to the end of {}...",
       "annotation" : "The File System component appended 2 files without error"
-    },
-    {
-      "name" : "FileHandling.fileManager.ShellCommandStarted",
-      "severity" : "ACTIVITY_HI",
-      "formalParams" : [
-        {
-          "name" : "command",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false,
-          "annotation" : "The command string"
-        }
-      ],
-      "id" : 83894285,
-      "format" : "Running shell command {}...",
-      "annotation" : "The File System component began executing a shell command"
     },
     {
       "name" : "FileHandling.fileManager.CreateDirectoryStarted",
@@ -11487,6 +11669,24 @@
       "format" : "Cannot run sequence from a port in state {}"
     },
     {
+      "name" : "Ref.cmdSeq0.InvalidSeqCancelCall",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "state",
+          "type" : {
+            "name" : "I32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : true
+          },
+          "ref" : false
+        }
+      ],
+      "id" : 268460034,
+      "format" : "Cannot cancel sequence from a port in state {}"
+    },
+    {
       "name" : "Ref.cmdSeq0.FileOpenError",
       "severity" : "WARNING_HI",
       "formalParams" : [
@@ -11510,7 +11710,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460034,
+      "id" : 268460035,
       "format" : "File open error encountered while opening {}: {}"
     },
     {
@@ -11545,7 +11745,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460035,
+      "id" : 268460036,
       "format" : "File write error encountered while writing {} bytes to {}: {}"
     },
     {
@@ -11580,7 +11780,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460036,
+      "id" : 268460037,
       "format" : "File read error encountered while reading {} of file {}: {}"
     },
     {
@@ -11605,7 +11805,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460037,
+      "id" : 268460038,
       "format" : "End of file encountered unexpectedly while reading {} of file {}"
     },
     {
@@ -11660,7 +11860,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460038,
+      "id" : 268460039,
       "format" : "Deserialize error encountered while reading {} of file {}: {} ({} bytes left out of {})"
     },
     {
@@ -11688,7 +11888,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460039,
+      "id" : 268460040,
       "format" : "Expected schema version {}, found {}"
     },
     {
@@ -11716,7 +11916,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460040,
+      "id" : 268460041,
       "format" : "Expected CRC {}, actual was {}"
     },
     {
@@ -11732,7 +11932,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460041,
+      "id" : 268460042,
       "format" : "File had {} extra bytes at the end"
     },
     {
@@ -11759,8 +11959,61 @@
           "ref" : false
         }
       ],
-      "id" : 268460042,
+      "id" : 268460043,
       "format" : "Buffer capacity of {} was not big enough for sequence {}"
+    },
+    {
+      "name" : "Ref.cmdSeq0.FileApiError",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "filePath",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 256
+          },
+          "ref" : false
+        },
+        {
+          "name" : "errorCode",
+          "type" : {
+            "name" : "I32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : true
+          },
+          "ref" : false
+        }
+      ],
+      "id" : 268460044,
+      "format" : "File system API error encountered while operating on file {}: {}"
+    },
+    {
+      "name" : "Ref.cmdSeq0.SequenceFilePathTooLong",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "baseDir",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 256
+          },
+          "ref" : false
+        },
+        {
+          "name" : "fileName",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 256
+          },
+          "ref" : false
+        }
+      ],
+      "id" : 268460045,
+      "format" : "Sequence file path was truncated: base directory {} and file name {} together exceed the maximum path length"
     },
     {
       "name" : "Ref.cmdSeq0.CommandFailed",
@@ -11802,7 +12055,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460043,
+      "id" : 268460046,
       "format" : "Failed to execute command opcode {} index {} in sequence file {}: response was {}"
     },
     {
@@ -11819,7 +12072,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460044,
+      "id" : 268460047,
       "format" : "Completed sequence file {}"
     },
     {
@@ -11836,7 +12089,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460045,
+      "id" : 268460048,
       "format" : "Cancelled sequence file {}"
     },
     {
@@ -11863,7 +12116,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460046,
+      "id" : 268460049,
       "format" : "Sequence {} exited with error code {}"
     },
     {
@@ -11900,7 +12153,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460047,
+      "id" : 268460050,
       "format" : "Unknown sequencer directive id {} at index {} in file {}"
     },
     {
@@ -11934,7 +12187,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460048,
+      "id" : 268460051,
       "format" : "Received a command response while not running a sequence (was in state {} opcode was {} response code {})"
     },
     {
@@ -11978,7 +12231,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460049,
+      "id" : 268460052,
       "format" : "Received a response from cmd opcode {} (response {}), but it was from a previous sequence, not the current one (old idx: {}, current idx: {})"
     },
     {
@@ -12002,7 +12255,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460050,
+      "id" : 268460053,
       "format" : "Received a response from cmd opcode {} (response {}) from this sequence, but was not awaiting a response"
     },
     {
@@ -12036,7 +12289,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460051,
+      "id" : 268460054,
       "format" : "Received a response from cmd opcode {} (response {}) from this sequence, but was awaiting directive opcode {}"
     },
     {
@@ -12068,7 +12321,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460052,
+      "id" : 268460055,
       "format" : "Received a response from cmd opcode {} (response {}) from this sequence, but was expecting a response from command opcode {}"
     },
     {
@@ -12112,7 +12365,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460053,
+      "id" : 268460056,
       "format" : "Received a response from the correct cmd (opcode {} response {}), but it was for a different instance of that opcode in the same sequence (actual idx {} expected {})"
     },
     {
@@ -12170,7 +12423,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460054,
+      "id" : 268460057,
       "format" : "Deserialize error encountered while reading directive opcode {} at index {}: {} ({} bytes left out of {})"
     },
     {
@@ -12198,7 +12451,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460055,
+      "id" : 268460058,
       "format" : "getTime() time base was {}, but tried to operate on it with time base {}"
     },
     {
@@ -12226,7 +12479,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460056,
+      "id" : 268460059,
       "format" : "getTime() time context was {}, but tried to operate on it with time context {}"
     },
     {
@@ -12261,7 +12514,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460057,
+      "id" : 268460060,
       "format" : "A command opcode {} at index {} timed out in sequence {}, causing the sequence to fail"
     },
     {
@@ -12298,7 +12551,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460058,
+      "id" : 268460061,
       "format" : "A directive opcode {} at index {} timed out in sequence {}, causing the sequence to fail"
     },
     {
@@ -12326,7 +12579,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460059,
+      "id" : 268460062,
       "format" : "A sequence specified it had {} args but the max was {}"
     },
     {
@@ -12354,7 +12607,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460060,
+      "id" : 268460063,
       "format" : "A sequence specified it had {} directives but the max was {}"
     },
     {
@@ -12387,7 +12640,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460061,
+      "id" : 268460064,
       "format" : "Expected {} bytes of arguments, but received {} in sequence file {}"
     },
     {
@@ -12401,81 +12654,10 @@
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false
-        },
-        {
-          "name" : "maxStackSize",
-          "type" : {
-            "name" : "Svc.Fpy.StackSizeType",
-            "kind" : "qualifiedIdentifier"
-          },
-          "ref" : false
-        },
-        {
-          "name" : "filePath",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false
         }
       ],
-      "id" : 268460062,
-      "format" : "Adding argument of size {} would exceed max stack size {} in sequence file {}"
-    },
-    {
-      "name" : "Ref.cmdSeq0.InvalidArgSpec",
-      "severity" : "WARNING_HI",
-      "formalParams" : [
-        {
-          "name" : "filePath",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false
-        }
-      ],
-      "id" : 268460063,
-      "format" : "Invalid argument specification in sequence file {}: arg_name or type_name cannot be empty"
-    },
-    {
-      "name" : "Ref.cmdSeq0.ArgSpecStringLengthExceedsMax",
-      "severity" : "WARNING_HI",
-      "formalParams" : [
-        {
-          "name" : "length",
-          "type" : {
-            "name" : "U8",
-            "kind" : "integer",
-            "size" : 8,
-            "signed" : false
-          },
-          "ref" : false
-        },
-        {
-          "name" : "max",
-          "type" : {
-            "name" : "U8",
-            "kind" : "integer",
-            "size" : 8,
-            "signed" : false
-          },
-          "ref" : false
-        },
-        {
-          "name" : "filePath",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false
-        }
-      ],
-      "id" : 268460064,
-      "format" : "Argument specification string length {} exceeds maximum {} in sequence file {}"
+      "id" : 268460065,
+      "format" : "Arguments of size {} would exceed max stack size."
     },
     {
       "name" : "Ref.cmdSeq0.SequencePaused",
@@ -12492,7 +12674,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460065,
+      "id" : 268460066,
       "format" : "Sequence paused before dispatching directive index {}"
     },
     {
@@ -12519,7 +12701,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460066,
+      "id" : 268460067,
       "format" : "Breakpoint set before directive index {}. Will break once: {}"
     },
     {
@@ -12527,7 +12709,7 @@
       "severity" : "ACTIVITY_HI",
       "formalParams" : [
       ],
-      "id" : 268460067,
+      "id" : 268460068,
       "format" : "Breakpoint cleared"
     },
     {
@@ -12553,7 +12735,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460068,
+      "id" : 268460069,
       "format" : "Sequence {}: {}"
     },
     {
@@ -12579,7 +12761,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460069,
+      "id" : 268460070,
       "format" : "Sequence {}: {}"
     },
     {
@@ -12605,7 +12787,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460070,
+      "id" : 268460071,
       "format" : "Sequence {}: {}"
     },
     {
@@ -12631,7 +12813,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460071,
+      "id" : 268460072,
       "format" : "Sequence {}: {}"
     },
     {
@@ -12657,7 +12839,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460072,
+      "id" : 268460073,
       "format" : "Sequence {}: {}"
     },
     {
@@ -12683,7 +12865,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460073,
+      "id" : 268460074,
       "format" : "Sequence {}: {}"
     },
     {
@@ -12709,7 +12891,7 @@
           "ref" : false
         }
       ],
-      "id" : 268460074,
+      "id" : 268460075,
       "format" : "Sequence {}: {}"
     },
     {
@@ -12749,6 +12931,24 @@
       "format" : "Cannot run sequence from a port in state {}"
     },
     {
+      "name" : "Ref.cmdSeq1.InvalidSeqCancelCall",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "state",
+          "type" : {
+            "name" : "I32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : true
+          },
+          "ref" : false
+        }
+      ],
+      "id" : 268464130,
+      "format" : "Cannot cancel sequence from a port in state {}"
+    },
+    {
       "name" : "Ref.cmdSeq1.FileOpenError",
       "severity" : "WARNING_HI",
       "formalParams" : [
@@ -12772,7 +12972,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464130,
+      "id" : 268464131,
       "format" : "File open error encountered while opening {}: {}"
     },
     {
@@ -12807,7 +13007,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464131,
+      "id" : 268464132,
       "format" : "File write error encountered while writing {} bytes to {}: {}"
     },
     {
@@ -12842,7 +13042,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464132,
+      "id" : 268464133,
       "format" : "File read error encountered while reading {} of file {}: {}"
     },
     {
@@ -12867,7 +13067,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464133,
+      "id" : 268464134,
       "format" : "End of file encountered unexpectedly while reading {} of file {}"
     },
     {
@@ -12922,7 +13122,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464134,
+      "id" : 268464135,
       "format" : "Deserialize error encountered while reading {} of file {}: {} ({} bytes left out of {})"
     },
     {
@@ -12950,7 +13150,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464135,
+      "id" : 268464136,
       "format" : "Expected schema version {}, found {}"
     },
     {
@@ -12978,7 +13178,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464136,
+      "id" : 268464137,
       "format" : "Expected CRC {}, actual was {}"
     },
     {
@@ -12994,7 +13194,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464137,
+      "id" : 268464138,
       "format" : "File had {} extra bytes at the end"
     },
     {
@@ -13021,8 +13221,61 @@
           "ref" : false
         }
       ],
-      "id" : 268464138,
+      "id" : 268464139,
       "format" : "Buffer capacity of {} was not big enough for sequence {}"
+    },
+    {
+      "name" : "Ref.cmdSeq1.FileApiError",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "filePath",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 256
+          },
+          "ref" : false
+        },
+        {
+          "name" : "errorCode",
+          "type" : {
+            "name" : "I32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : true
+          },
+          "ref" : false
+        }
+      ],
+      "id" : 268464140,
+      "format" : "File system API error encountered while operating on file {}: {}"
+    },
+    {
+      "name" : "Ref.cmdSeq1.SequenceFilePathTooLong",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "baseDir",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 256
+          },
+          "ref" : false
+        },
+        {
+          "name" : "fileName",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 256
+          },
+          "ref" : false
+        }
+      ],
+      "id" : 268464141,
+      "format" : "Sequence file path was truncated: base directory {} and file name {} together exceed the maximum path length"
     },
     {
       "name" : "Ref.cmdSeq1.CommandFailed",
@@ -13064,7 +13317,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464139,
+      "id" : 268464142,
       "format" : "Failed to execute command opcode {} index {} in sequence file {}: response was {}"
     },
     {
@@ -13081,7 +13334,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464140,
+      "id" : 268464143,
       "format" : "Completed sequence file {}"
     },
     {
@@ -13098,7 +13351,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464141,
+      "id" : 268464144,
       "format" : "Cancelled sequence file {}"
     },
     {
@@ -13125,7 +13378,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464142,
+      "id" : 268464145,
       "format" : "Sequence {} exited with error code {}"
     },
     {
@@ -13162,7 +13415,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464143,
+      "id" : 268464146,
       "format" : "Unknown sequencer directive id {} at index {} in file {}"
     },
     {
@@ -13196,7 +13449,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464144,
+      "id" : 268464147,
       "format" : "Received a command response while not running a sequence (was in state {} opcode was {} response code {})"
     },
     {
@@ -13240,7 +13493,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464145,
+      "id" : 268464148,
       "format" : "Received a response from cmd opcode {} (response {}), but it was from a previous sequence, not the current one (old idx: {}, current idx: {})"
     },
     {
@@ -13264,7 +13517,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464146,
+      "id" : 268464149,
       "format" : "Received a response from cmd opcode {} (response {}) from this sequence, but was not awaiting a response"
     },
     {
@@ -13298,7 +13551,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464147,
+      "id" : 268464150,
       "format" : "Received a response from cmd opcode {} (response {}) from this sequence, but was awaiting directive opcode {}"
     },
     {
@@ -13330,7 +13583,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464148,
+      "id" : 268464151,
       "format" : "Received a response from cmd opcode {} (response {}) from this sequence, but was expecting a response from command opcode {}"
     },
     {
@@ -13374,7 +13627,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464149,
+      "id" : 268464152,
       "format" : "Received a response from the correct cmd (opcode {} response {}), but it was for a different instance of that opcode in the same sequence (actual idx {} expected {})"
     },
     {
@@ -13432,7 +13685,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464150,
+      "id" : 268464153,
       "format" : "Deserialize error encountered while reading directive opcode {} at index {}: {} ({} bytes left out of {})"
     },
     {
@@ -13460,7 +13713,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464151,
+      "id" : 268464154,
       "format" : "getTime() time base was {}, but tried to operate on it with time base {}"
     },
     {
@@ -13488,7 +13741,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464152,
+      "id" : 268464155,
       "format" : "getTime() time context was {}, but tried to operate on it with time context {}"
     },
     {
@@ -13523,7 +13776,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464153,
+      "id" : 268464156,
       "format" : "A command opcode {} at index {} timed out in sequence {}, causing the sequence to fail"
     },
     {
@@ -13560,7 +13813,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464154,
+      "id" : 268464157,
       "format" : "A directive opcode {} at index {} timed out in sequence {}, causing the sequence to fail"
     },
     {
@@ -13588,7 +13841,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464155,
+      "id" : 268464158,
       "format" : "A sequence specified it had {} args but the max was {}"
     },
     {
@@ -13616,7 +13869,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464156,
+      "id" : 268464159,
       "format" : "A sequence specified it had {} directives but the max was {}"
     },
     {
@@ -13649,7 +13902,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464157,
+      "id" : 268464160,
       "format" : "Expected {} bytes of arguments, but received {} in sequence file {}"
     },
     {
@@ -13663,81 +13916,10 @@
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false
-        },
-        {
-          "name" : "maxStackSize",
-          "type" : {
-            "name" : "Svc.Fpy.StackSizeType",
-            "kind" : "qualifiedIdentifier"
-          },
-          "ref" : false
-        },
-        {
-          "name" : "filePath",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false
         }
       ],
-      "id" : 268464158,
-      "format" : "Adding argument of size {} would exceed max stack size {} in sequence file {}"
-    },
-    {
-      "name" : "Ref.cmdSeq1.InvalidArgSpec",
-      "severity" : "WARNING_HI",
-      "formalParams" : [
-        {
-          "name" : "filePath",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false
-        }
-      ],
-      "id" : 268464159,
-      "format" : "Invalid argument specification in sequence file {}: arg_name or type_name cannot be empty"
-    },
-    {
-      "name" : "Ref.cmdSeq1.ArgSpecStringLengthExceedsMax",
-      "severity" : "WARNING_HI",
-      "formalParams" : [
-        {
-          "name" : "length",
-          "type" : {
-            "name" : "U8",
-            "kind" : "integer",
-            "size" : 8,
-            "signed" : false
-          },
-          "ref" : false
-        },
-        {
-          "name" : "max",
-          "type" : {
-            "name" : "U8",
-            "kind" : "integer",
-            "size" : 8,
-            "signed" : false
-          },
-          "ref" : false
-        },
-        {
-          "name" : "filePath",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false
-        }
-      ],
-      "id" : 268464160,
-      "format" : "Argument specification string length {} exceeds maximum {} in sequence file {}"
+      "id" : 268464161,
+      "format" : "Arguments of size {} would exceed max stack size."
     },
     {
       "name" : "Ref.cmdSeq1.SequencePaused",
@@ -13754,7 +13936,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464161,
+      "id" : 268464162,
       "format" : "Sequence paused before dispatching directive index {}"
     },
     {
@@ -13781,7 +13963,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464162,
+      "id" : 268464163,
       "format" : "Breakpoint set before directive index {}. Will break once: {}"
     },
     {
@@ -13789,7 +13971,7 @@
       "severity" : "ACTIVITY_HI",
       "formalParams" : [
       ],
-      "id" : 268464163,
+      "id" : 268464164,
       "format" : "Breakpoint cleared"
     },
     {
@@ -13815,7 +13997,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464164,
+      "id" : 268464165,
       "format" : "Sequence {}: {}"
     },
     {
@@ -13841,7 +14023,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464165,
+      "id" : 268464166,
       "format" : "Sequence {}: {}"
     },
     {
@@ -13867,7 +14049,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464166,
+      "id" : 268464167,
       "format" : "Sequence {}: {}"
     },
     {
@@ -13893,7 +14075,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464167,
+      "id" : 268464168,
       "format" : "Sequence {}: {}"
     },
     {
@@ -13919,7 +14101,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464168,
+      "id" : 268464169,
       "format" : "Sequence {}: {}"
     },
     {
@@ -13945,7 +14127,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464169,
+      "id" : 268464170,
       "format" : "Sequence {}: {}"
     },
     {
@@ -13971,7 +14153,7 @@
           "ref" : false
         }
       ],
-      "id" : 268464170,
+      "id" : 268464171,
       "format" : "Sequence {}: {}"
     },
     {
@@ -14153,6 +14335,24 @@
       "format" : "Cannot run sequence from a port in state {}"
     },
     {
+      "name" : "Ref.cmdSeq2.InvalidSeqCancelCall",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "state",
+          "type" : {
+            "name" : "I32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : true
+          },
+          "ref" : false
+        }
+      ],
+      "id" : 268472322,
+      "format" : "Cannot cancel sequence from a port in state {}"
+    },
+    {
       "name" : "Ref.cmdSeq2.FileOpenError",
       "severity" : "WARNING_HI",
       "formalParams" : [
@@ -14176,7 +14376,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472322,
+      "id" : 268472323,
       "format" : "File open error encountered while opening {}: {}"
     },
     {
@@ -14211,7 +14411,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472323,
+      "id" : 268472324,
       "format" : "File write error encountered while writing {} bytes to {}: {}"
     },
     {
@@ -14246,7 +14446,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472324,
+      "id" : 268472325,
       "format" : "File read error encountered while reading {} of file {}: {}"
     },
     {
@@ -14271,7 +14471,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472325,
+      "id" : 268472326,
       "format" : "End of file encountered unexpectedly while reading {} of file {}"
     },
     {
@@ -14326,7 +14526,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472326,
+      "id" : 268472327,
       "format" : "Deserialize error encountered while reading {} of file {}: {} ({} bytes left out of {})"
     },
     {
@@ -14354,7 +14554,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472327,
+      "id" : 268472328,
       "format" : "Expected schema version {}, found {}"
     },
     {
@@ -14382,7 +14582,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472328,
+      "id" : 268472329,
       "format" : "Expected CRC {}, actual was {}"
     },
     {
@@ -14398,7 +14598,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472329,
+      "id" : 268472330,
       "format" : "File had {} extra bytes at the end"
     },
     {
@@ -14425,8 +14625,61 @@
           "ref" : false
         }
       ],
-      "id" : 268472330,
+      "id" : 268472331,
       "format" : "Buffer capacity of {} was not big enough for sequence {}"
+    },
+    {
+      "name" : "Ref.cmdSeq2.FileApiError",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "filePath",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 256
+          },
+          "ref" : false
+        },
+        {
+          "name" : "errorCode",
+          "type" : {
+            "name" : "I32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : true
+          },
+          "ref" : false
+        }
+      ],
+      "id" : 268472332,
+      "format" : "File system API error encountered while operating on file {}: {}"
+    },
+    {
+      "name" : "Ref.cmdSeq2.SequenceFilePathTooLong",
+      "severity" : "WARNING_HI",
+      "formalParams" : [
+        {
+          "name" : "baseDir",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 256
+          },
+          "ref" : false
+        },
+        {
+          "name" : "fileName",
+          "type" : {
+            "name" : "string",
+            "kind" : "string",
+            "size" : 256
+          },
+          "ref" : false
+        }
+      ],
+      "id" : 268472333,
+      "format" : "Sequence file path was truncated: base directory {} and file name {} together exceed the maximum path length"
     },
     {
       "name" : "Ref.cmdSeq2.CommandFailed",
@@ -14468,7 +14721,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472331,
+      "id" : 268472334,
       "format" : "Failed to execute command opcode {} index {} in sequence file {}: response was {}"
     },
     {
@@ -14485,7 +14738,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472332,
+      "id" : 268472335,
       "format" : "Completed sequence file {}"
     },
     {
@@ -14502,7 +14755,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472333,
+      "id" : 268472336,
       "format" : "Cancelled sequence file {}"
     },
     {
@@ -14529,7 +14782,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472334,
+      "id" : 268472337,
       "format" : "Sequence {} exited with error code {}"
     },
     {
@@ -14566,7 +14819,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472335,
+      "id" : 268472338,
       "format" : "Unknown sequencer directive id {} at index {} in file {}"
     },
     {
@@ -14600,7 +14853,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472336,
+      "id" : 268472339,
       "format" : "Received a command response while not running a sequence (was in state {} opcode was {} response code {})"
     },
     {
@@ -14644,7 +14897,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472337,
+      "id" : 268472340,
       "format" : "Received a response from cmd opcode {} (response {}), but it was from a previous sequence, not the current one (old idx: {}, current idx: {})"
     },
     {
@@ -14668,7 +14921,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472338,
+      "id" : 268472341,
       "format" : "Received a response from cmd opcode {} (response {}) from this sequence, but was not awaiting a response"
     },
     {
@@ -14702,7 +14955,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472339,
+      "id" : 268472342,
       "format" : "Received a response from cmd opcode {} (response {}) from this sequence, but was awaiting directive opcode {}"
     },
     {
@@ -14734,7 +14987,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472340,
+      "id" : 268472343,
       "format" : "Received a response from cmd opcode {} (response {}) from this sequence, but was expecting a response from command opcode {}"
     },
     {
@@ -14778,7 +15031,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472341,
+      "id" : 268472344,
       "format" : "Received a response from the correct cmd (opcode {} response {}), but it was for a different instance of that opcode in the same sequence (actual idx {} expected {})"
     },
     {
@@ -14836,7 +15089,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472342,
+      "id" : 268472345,
       "format" : "Deserialize error encountered while reading directive opcode {} at index {}: {} ({} bytes left out of {})"
     },
     {
@@ -14864,7 +15117,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472343,
+      "id" : 268472346,
       "format" : "getTime() time base was {}, but tried to operate on it with time base {}"
     },
     {
@@ -14892,7 +15145,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472344,
+      "id" : 268472347,
       "format" : "getTime() time context was {}, but tried to operate on it with time context {}"
     },
     {
@@ -14927,7 +15180,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472345,
+      "id" : 268472348,
       "format" : "A command opcode {} at index {} timed out in sequence {}, causing the sequence to fail"
     },
     {
@@ -14964,7 +15217,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472346,
+      "id" : 268472349,
       "format" : "A directive opcode {} at index {} timed out in sequence {}, causing the sequence to fail"
     },
     {
@@ -14992,7 +15245,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472347,
+      "id" : 268472350,
       "format" : "A sequence specified it had {} args but the max was {}"
     },
     {
@@ -15020,7 +15273,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472348,
+      "id" : 268472351,
       "format" : "A sequence specified it had {} directives but the max was {}"
     },
     {
@@ -15053,7 +15306,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472349,
+      "id" : 268472352,
       "format" : "Expected {} bytes of arguments, but received {} in sequence file {}"
     },
     {
@@ -15067,81 +15320,10 @@
             "kind" : "qualifiedIdentifier"
           },
           "ref" : false
-        },
-        {
-          "name" : "maxStackSize",
-          "type" : {
-            "name" : "Svc.Fpy.StackSizeType",
-            "kind" : "qualifiedIdentifier"
-          },
-          "ref" : false
-        },
-        {
-          "name" : "filePath",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false
         }
       ],
-      "id" : 268472350,
-      "format" : "Adding argument of size {} would exceed max stack size {} in sequence file {}"
-    },
-    {
-      "name" : "Ref.cmdSeq2.InvalidArgSpec",
-      "severity" : "WARNING_HI",
-      "formalParams" : [
-        {
-          "name" : "filePath",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false
-        }
-      ],
-      "id" : 268472351,
-      "format" : "Invalid argument specification in sequence file {}: arg_name or type_name cannot be empty"
-    },
-    {
-      "name" : "Ref.cmdSeq2.ArgSpecStringLengthExceedsMax",
-      "severity" : "WARNING_HI",
-      "formalParams" : [
-        {
-          "name" : "length",
-          "type" : {
-            "name" : "U8",
-            "kind" : "integer",
-            "size" : 8,
-            "signed" : false
-          },
-          "ref" : false
-        },
-        {
-          "name" : "max",
-          "type" : {
-            "name" : "U8",
-            "kind" : "integer",
-            "size" : 8,
-            "signed" : false
-          },
-          "ref" : false
-        },
-        {
-          "name" : "filePath",
-          "type" : {
-            "name" : "string",
-            "kind" : "string",
-            "size" : 256
-          },
-          "ref" : false
-        }
-      ],
-      "id" : 268472352,
-      "format" : "Argument specification string length {} exceeds maximum {} in sequence file {}"
+      "id" : 268472353,
+      "format" : "Arguments of size {} would exceed max stack size."
     },
     {
       "name" : "Ref.cmdSeq2.SequencePaused",
@@ -15158,7 +15340,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472353,
+      "id" : 268472354,
       "format" : "Sequence paused before dispatching directive index {}"
     },
     {
@@ -15185,7 +15367,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472354,
+      "id" : 268472355,
       "format" : "Breakpoint set before directive index {}. Will break once: {}"
     },
     {
@@ -15193,7 +15375,7 @@
       "severity" : "ACTIVITY_HI",
       "formalParams" : [
       ],
-      "id" : 268472355,
+      "id" : 268472356,
       "format" : "Breakpoint cleared"
     },
     {
@@ -15219,7 +15401,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472356,
+      "id" : 268472357,
       "format" : "Sequence {}: {}"
     },
     {
@@ -15245,7 +15427,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472357,
+      "id" : 268472358,
       "format" : "Sequence {}: {}"
     },
     {
@@ -15271,7 +15453,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472358,
+      "id" : 268472359,
       "format" : "Sequence {}: {}"
     },
     {
@@ -15297,7 +15479,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472359,
+      "id" : 268472360,
       "format" : "Sequence {}: {}"
     },
     {
@@ -15323,7 +15505,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472360,
+      "id" : 268472361,
       "format" : "Sequence {}: {}"
     },
     {
@@ -15349,7 +15531,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472361,
+      "id" : 268472362,
       "format" : "Sequence {}: {}"
     },
     {
@@ -15375,7 +15557,7 @@
           "ref" : false
         }
       ],
-      "id" : 268472362,
+      "id" : 268472363,
       "format" : "Sequence {}: {}"
     },
     {
@@ -17643,6 +17825,17 @@
       "annotation" : "value of prm STATEMENT_TIMEOUT_SECS"
     },
     {
+      "name" : "Ref.cmdSeq0.PRM_SEQ_BASE_DIR",
+      "type" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 240
+      },
+      "id" : 268460053,
+      "telemetryUpdate" : "on change",
+      "annotation" : "value of prm SEQ_BASE_DIR"
+    },
+    {
       "name" : "Ref.cmdSeq1.State",
       "type" : {
         "name" : "FwEnumStoreType",
@@ -17876,6 +18069,17 @@
       "id" : 268464148,
       "telemetryUpdate" : "on change",
       "annotation" : "value of prm STATEMENT_TIMEOUT_SECS"
+    },
+    {
+      "name" : "Ref.cmdSeq1.PRM_SEQ_BASE_DIR",
+      "type" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 240
+      },
+      "id" : 268464149,
+      "telemetryUpdate" : "on change",
+      "annotation" : "value of prm SEQ_BASE_DIR"
     },
     {
       "name" : "Ref.seqDisp.dispatchedCount",
@@ -18147,6 +18351,17 @@
       "id" : 268472340,
       "telemetryUpdate" : "on change",
       "annotation" : "value of prm STATEMENT_TIMEOUT_SECS"
+    },
+    {
+      "name" : "Ref.cmdSeq2.PRM_SEQ_BASE_DIR",
+      "type" : {
+        "name" : "string",
+        "kind" : "string",
+        "size" : 240
+      },
+      "id" : 268472341,
+      "telemetryUpdate" : "on change",
+      "annotation" : "value of prm SEQ_BASE_DIR"
     },
     {
       "name" : "Ref.sendBuffComp.PacketsSent",

--- a/test/fpy/test_assembler.py
+++ b/test/fpy/test_assembler.py
@@ -1056,18 +1056,21 @@ class TestArgSpecsBinaryFormat:
         dirs = [NoOpDirective()]
         specs = [("x", "U32", 4)]
         serialized, _ = serialize_directives(dirs, arg_specs=specs)
-        # After header: 1 byte arg_name_len + "x" (1 byte) + 1 byte type_name_len + "U32" (3 bytes) + U32 size (4 bytes)
+        # Names are serialized as strings with a FwSizeStoreType length prefix.
+        # The default size store type is U16 (16 bits / 2 bytes).
+        # After header: 2 byte arg_name_len + "x" (1 byte)
+        #             + 2 byte type_name_len + "U32" (3 bytes) + U32 size (4 bytes)
         offset = HEADER_SIZE
-        arg_name_len = serialized[offset]
+        arg_name_len = struct.unpack_from("!H", serialized, offset)[0]
         assert arg_name_len == 1
-        arg_name = serialized[offset + 1 : offset + 2].decode("utf-8")
+        arg_name = serialized[offset + 2 : offset + 3].decode("utf-8")
         assert arg_name == "x"
-        offset += 2
-        type_name_len = serialized[offset]
+        offset += 3
+        type_name_len = struct.unpack_from("!H", serialized, offset)[0]
         assert type_name_len == 3
-        type_name = serialized[offset + 1 : offset + 4].decode("utf-8")
+        type_name = serialized[offset + 2 : offset + 5].decode("utf-8")
         assert type_name == "U32"
-        size = struct.unpack_from("!I", serialized, offset + 4)[0]
+        size = struct.unpack_from("!I", serialized, offset + 5)[0]
         assert size == 4
 
     def test_large_type_size_roundtrip(self):

--- a/test/fpy/test_commands.py
+++ b/test/fpy/test_commands.py
@@ -259,7 +259,7 @@ class TestAssertCmdSuccess:
         """Bare failing command with flag=True should exit with error."""
         seq = """
 flags.assert_cmd_success = True
-Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
 """
         assert_run_failure(
             fprime_test_api,
@@ -271,7 +271,7 @@ Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
         """Bare failing command with flag=False should not halt."""
         seq = """
 flags.assert_cmd_success = False
-Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
 """
         assert_run_success(fprime_test_api, seq)
 
@@ -281,7 +281,7 @@ Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
         """Captured failing command with flag=True should NOT auto-assert."""
         seq = """
 flags.assert_cmd_success = True
-resp: Fw.CmdResponse = Ref.cmdSeq0.RUN("test", Svc.FpySequencer.BlockState.NO_BLOCK)
+resp: Fw.CmdResponse = Ref.cmdSeq0.RUN("test", Svc.BlockState.NO_BLOCK)
 assert resp == Fw.CmdResponse.EXECUTION_ERROR
 """
         assert_run_success(fprime_test_api, seq)
@@ -290,7 +290,7 @@ assert resp == Fw.CmdResponse.EXECUTION_ERROR
         """Captured failing command with flag=False should not halt."""
         seq = """
 flags.assert_cmd_success = False
-resp: Fw.CmdResponse = Ref.cmdSeq0.RUN("test", Svc.FpySequencer.BlockState.NO_BLOCK)
+resp: Fw.CmdResponse = Ref.cmdSeq0.RUN("test", Svc.BlockState.NO_BLOCK)
 assert resp == Fw.CmdResponse.EXECUTION_ERROR
 """
         assert_run_success(fprime_test_api, seq)
@@ -320,7 +320,7 @@ CdhCore.cmdDisp.CMD_NO_OP()
         seq = """
 flags.assert_cmd_success = True
 flags.assert_cmd_success = False
-Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
 """
         assert_run_success(fprime_test_api, seq)
 
@@ -331,7 +331,7 @@ Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
         seq = """
 flags.assert_cmd_success = True
 if True:
-    Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+    Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
 """
         assert_run_failure(
             fprime_test_api,
@@ -345,7 +345,7 @@ if True:
 flags.assert_cmd_success = True
 x: bool = True
 while x:
-    Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+    Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
     x = False
 """
         assert_run_failure(
@@ -359,7 +359,7 @@ while x:
         seq = """
 flags.assert_cmd_success = True
 def do_cmd():
-    Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+    Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
 do_cmd()
 """
         assert_run_failure(
@@ -373,7 +373,7 @@ do_cmd()
         seq = """
 flags.assert_cmd_success = False
 def do_cmd():
-    Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+    Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
 do_cmd()
 """
         assert_run_success(fprime_test_api, seq)
@@ -383,7 +383,7 @@ do_cmd()
         seq = """
 flags.assert_cmd_success = True
 for i in 0 .. 1:
-    Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+    Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
 """
         assert_run_failure(
             fprime_test_api,

--- a/test/fpy/test_depend.py
+++ b/test/fpy/test_depend.py
@@ -34,18 +34,18 @@ class TestNoDependencies:
 
     def test_seq_run_without_args_is_not_a_dep(self):
         # RUN (no varargs) is not flagged as a seq-run-with-args command
-        assert _collect('Ref.seqDisp.RUN("seq.bin", Fw.Wait.WAIT)\n') == []
+        assert _collect('Ref.seqDisp.RUN("seq.bin", Svc.BlockState.BLOCK)\n') == []
 
 
 class TestSingleDependency:
     def test_bin_name_resolved_with_ground_binary_dir(self):
-        seq = 'Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.WAIT)\n'
+        seq = 'Ref.seqDisp.RUN_ARGS("child.bin", Svc.BlockState.BLOCK)\n'
         deps = _collect(seq, ground_binary_dir="/tmp/bins")
         assert deps == ["/tmp/bins/child.bin"]
 
     def test_bin_does_not_need_to_exist(self):
         # The main differentiator from the compiler: missing binary is not an error
-        seq = 'Ref.seqDisp.RUN_ARGS("nonexistent.bin", Fw.Wait.WAIT)\n'
+        seq = 'Ref.seqDisp.RUN_ARGS("nonexistent.bin", Svc.BlockState.BLOCK)\n'
         deps = _collect(seq, ground_binary_dir="/tmp/bins")
         assert deps == ["/tmp/bins/nonexistent.bin"]
 
@@ -53,7 +53,7 @@ class TestSingleDependency:
         seq = """\
 x: I32 = 1
 if x == 1:
-    Ref.seqDisp.RUN_ARGS("branch.bin", Fw.Wait.WAIT)
+    Ref.seqDisp.RUN_ARGS("branch.bin", Svc.BlockState.BLOCK)
 """
         deps = _collect(seq, ground_binary_dir="/tmp")
         assert deps == ["/tmp/branch.bin"]
@@ -62,7 +62,7 @@ if x == 1:
         seq = """\
 x: I32 = 3
 while x > 0:
-    Ref.seqDisp.RUN_ARGS("loop.bin", Fw.Wait.NO_WAIT)
+    Ref.seqDisp.RUN_ARGS("loop.bin", Svc.BlockState.NO_BLOCK)
     x = x - 1
 """
         deps = _collect(seq, ground_binary_dir="/tmp")
@@ -71,7 +71,7 @@ while x > 0:
     def test_seq_called_inside_function(self):
         seq = """\
 def run_it():
-    Ref.seqDisp.RUN_ARGS("helper.bin", Fw.Wait.WAIT)
+    Ref.seqDisp.RUN_ARGS("helper.bin", Svc.BlockState.BLOCK)
 run_it()
 """
         deps = _collect(seq, ground_binary_dir="/tmp")
@@ -81,25 +81,25 @@ run_it()
 class TestMultipleDependencies:
     def test_two_distinct_bins(self):
         seq = """\
-Ref.seqDisp.RUN_ARGS("a.bin", Fw.Wait.WAIT)
-Ref.seqDisp.RUN_ARGS("b.bin", Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS("a.bin", Svc.BlockState.BLOCK)
+Ref.seqDisp.RUN_ARGS("b.bin", Svc.BlockState.BLOCK)
 """
         deps = _collect(seq, ground_binary_dir="/tmp")
         assert deps == ["/tmp/a.bin", "/tmp/b.bin"]
 
     def test_order_matches_source_order(self):
         seq = """\
-Ref.seqDisp.RUN_ARGS("first.bin", Fw.Wait.WAIT)
-Ref.seqDisp.RUN_ARGS("second.bin", Fw.Wait.WAIT)
-Ref.seqDisp.RUN_ARGS("third.bin", Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS("first.bin", Svc.BlockState.BLOCK)
+Ref.seqDisp.RUN_ARGS("second.bin", Svc.BlockState.BLOCK)
+Ref.seqDisp.RUN_ARGS("third.bin", Svc.BlockState.BLOCK)
 """
         deps = _collect(seq, ground_binary_dir="/tmp")
         assert deps == ["/tmp/first.bin", "/tmp/second.bin", "/tmp/third.bin"]
 
     def test_duplicate_call_deduplicated(self):
         seq = """\
-Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.WAIT)
-Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.NO_WAIT)
+Ref.seqDisp.RUN_ARGS("child.bin", Svc.BlockState.BLOCK)
+Ref.seqDisp.RUN_ARGS("child.bin", Svc.BlockState.NO_BLOCK)
 """
         deps = _collect(seq, ground_binary_dir="/tmp")
         assert deps == ["/tmp/child.bin"]
@@ -107,7 +107,7 @@ Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.NO_WAIT)
     def test_mix_of_seq_run_and_regular_commands(self):
         seq = """\
 CdhCore.cmdDisp.CMD_NO_OP()
-Ref.seqDisp.RUN_ARGS("only_this.bin", Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS("only_this.bin", Svc.BlockState.BLOCK)
 CdhCore.cmdDisp.CMD_NO_OP()
 """
         deps = _collect(seq, ground_binary_dir="/tmp")
@@ -117,13 +117,13 @@ CdhCore.cmdDisp.CMD_NO_OP()
 class TestGroundBinaryDirHandling:
     def test_ground_binary_dir_prepended_to_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            seq = 'Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.WAIT)\n'
+            seq = 'Ref.seqDisp.RUN_ARGS("child.bin", Svc.BlockState.BLOCK)\n'
             deps = _collect(seq, ground_binary_dir=tmpdir)
             assert deps == [str(Path(tmpdir) / "child.bin")]
 
     def test_no_ground_binary_dir_returns_bare_names(self):
         # Without a ground_binary_dir the raw filename is returned as-is
-        seq = 'Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.WAIT)\n'
+        seq = 'Ref.seqDisp.RUN_ARGS("child.bin", Svc.BlockState.BLOCK)\n'
         deps = _collect(seq, ground_binary_dir=None)
         assert deps == ["child.bin"]
 
@@ -132,7 +132,7 @@ class TestErrorCases:
     def test_non_string_literal_filename_is_compile_error(self):
         seq = """\
 name: I32 = 0
-Ref.seqDisp.RUN_ARGS(name, Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS(name, Svc.BlockState.BLOCK)
 """
         fpy.error.file_name = "<test>"
         body = text_to_ast(seq)
@@ -157,8 +157,8 @@ class TestDependMainCLI:
 
         fpy_path = tmp_path / "seq.fpy"
         fpy_path.write_text(
-            'Ref.seqDisp.RUN_ARGS("a.bin", Fw.Wait.WAIT)\n'
-            'Ref.seqDisp.RUN_ARGS("b.bin", Fw.Wait.WAIT)\n'
+            'Ref.seqDisp.RUN_ARGS("a.bin", Svc.BlockState.BLOCK)\n'
+            'Ref.seqDisp.RUN_ARGS("b.bin", Svc.BlockState.BLOCK)\n'
         )
         depend_main([str(fpy_path), "-d", default_dictionary, "-g", str(tmp_path)])
         lines = capsys.readouterr().out.splitlines()
@@ -168,7 +168,7 @@ class TestDependMainCLI:
         from fpy.main import depend_main
 
         fpy_path = tmp_path / "seq.fpy"
-        fpy_path.write_text('Ref.seqDisp.RUN_ARGS("ghost.bin", Fw.Wait.WAIT)\n')
+        fpy_path.write_text('Ref.seqDisp.RUN_ARGS("ghost.bin", Svc.BlockState.BLOCK)\n')
         # ghost.bin is never created — should still succeed
         depend_main([str(fpy_path), "-d", default_dictionary, "-g", str(tmp_path)])
         assert capsys.readouterr().out.strip() == str(tmp_path / "ghost.bin")
@@ -177,7 +177,7 @@ class TestDependMainCLI:
         from fpy.main import depend_main
 
         fpy_path = tmp_path / "seq.fpy"
-        fpy_path.write_text('Ref.seqDisp.RUN_ARGS("child.bin", Fw.Wait.WAIT)\n')
+        fpy_path.write_text('Ref.seqDisp.RUN_ARGS("child.bin", Svc.BlockState.BLOCK)\n')
         depend_main([str(fpy_path), "-d", default_dictionary])
         # Without -g, ground_binary_dir defaults to the input file's directory
         assert capsys.readouterr().out.strip() == str(tmp_path / "child.bin")

--- a/test/fpy/test_dictionary.py
+++ b/test/fpy/test_dictionary.py
@@ -2896,3 +2896,68 @@ class TestTypeCtorDefaults:
         ctor = current
         for _, _, default in ctor.args:
             assert default is not None
+
+
+# ===================================================================
+# Section: User-configurable Fw* types updated from the dictionary
+# ===================================================================
+
+
+class TestConfigurableTypes:
+    """The Fw* types are updated in place from the dictionary before use."""
+
+    @pytest.fixture(autouse=True)
+    def restore_configurable_types(self):
+        """Save/restore the in-place-mutated configurable-type singletons."""
+        from fpy import types as types_mod
+        from fpy.bytecode import directives as dir_mod
+
+        targets = [
+            dir_mod.FwOpcodeType,
+            dir_mod.FwChanIdType,
+            dir_mod.FwPrmIdType,
+            types_mod.FwSizeStoreType,
+        ]
+        snaps = [(t, t.kind, t.name) for t in targets]
+        yield
+        for t, kind, name in snaps:
+            t.kind, t.name = kind, name
+
+    def test_opcode_type_default_then_updated(self):
+        from fpy.bytecode.directives import (
+            FwOpcodeType,
+            ConstCmdDirective,
+            update_configurable_types_from_dict,
+        )
+
+        # Default is U32.
+        assert FwOpcodeType.kind == TypeKind.U32
+        assert ConstCmdDirective(cmd_opcode=0x1234, args=b"").serialize_args() == (
+            FpyValue(U32, 0x1234).serialize()
+        )
+
+        # The dictionary may redefine it; here we shrink the opcode to U16.
+        update_configurable_types_from_dict({"FwOpcodeType": U16})
+        assert FwOpcodeType.kind == TypeKind.U16
+        # The directive now serializes its opcode with the updated width.
+        assert ConstCmdDirective(cmd_opcode=0x1234, args=b"").serialize_args() == (
+            FpyValue(U16, 0x1234).serialize()
+        )
+
+    def test_size_store_type_default_then_updated(self):
+        from fpy.bytecode.directives import update_configurable_types_from_dict
+        from fpy.types import FwSizeStoreType
+
+        string_type = FpyType(TypeKind.STRING, "String_10", max_length=10)
+
+        # Default string length prefix is U16.
+        assert FwSizeStoreType.kind == TypeKind.U16
+        assert FpyValue(string_type, "hi").serialize() == (
+            FpyValue(U16, 2).serialize() + b"hi"
+        )
+
+        update_configurable_types_from_dict({"FwSizeStoreType": U8})
+        assert FwSizeStoreType.kind == TypeKind.U8
+        assert FpyValue(string_type, "hi").serialize() == (
+            FpyValue(U8, 2).serialize() + b"hi"
+        )

--- a/test/fpy/test_dictionary.py
+++ b/test/fpy/test_dictionary.py
@@ -2395,26 +2395,26 @@ class TestLoadDictionary:
 
     def test_type_counts(self):
         d = load_dictionary(REF_DICT_PATH)
-        assert len(d["type_defs"]) == 93
+        assert len(d["type_defs"]) == 95
 
     def test_command_counts(self):
         d = load_dictionary(REF_DICT_PATH)
-        assert len(d["cmd_id_dict"]) == 139
-        assert len(d["cmd_name_dict"]) == 139
+        assert len(d["cmd_id_dict"]) == 144
+        assert len(d["cmd_name_dict"]) == 144
 
     def test_channel_counts(self):
         d = load_dictionary(REF_DICT_PATH)
-        assert len(d["ch_id_dict"]) == 222
-        assert len(d["ch_name_dict"]) == 222
+        assert len(d["ch_id_dict"]) == 225
+        assert len(d["ch_name_dict"]) == 225
 
     def test_parameter_counts(self):
         d = load_dictionary(REF_DICT_PATH)
-        assert len(d["prm_id_dict"]) == 12
-        assert len(d["prm_name_dict"]) == 12
+        assert len(d["prm_id_dict"]) == 15
+        assert len(d["prm_name_dict"]) == 15
 
     def test_constant_counts(self):
         d = load_dictionary(REF_DICT_PATH)
-        assert len(d["constants"]) == 18
+        assert len(d["constants"]) == 19
 
     def test_command_attributes(self):
         """Verify CmdDef attributes match expected API."""

--- a/test/fpy/test_dictionary.py
+++ b/test/fpy/test_dictionary.py
@@ -2903,14 +2903,16 @@ class TestTypeCtorDefaults:
 # ===================================================================
 
 
-class TestConfigurableTypes:
+class TestTypeAliasesFromDict:
     """The Fw* types are updated in place from the dictionary before use."""
 
     @pytest.fixture(autouse=True)
     def restore_configurable_types(self):
-        """Save/restore the in-place-mutated configurable-type singletons."""
+        """Save/restore the in-place-mutated configurable-type singletons and
+        clear the dictionary/scope caches around each test."""
         from fpy import types as types_mod
         from fpy.bytecode import directives as dir_mod
+        from fpy.compiler import _build_global_scopes
 
         targets = [
             dir_mod.FwOpcodeType,
@@ -2919,7 +2921,11 @@ class TestConfigurableTypes:
             types_mod.FwSizeStoreType,
         ]
         snaps = [(t, t.kind, t.name) for t in targets]
+        load_dictionary.cache_clear()
+        _build_global_scopes.cache_clear()
         yield
+        load_dictionary.cache_clear()
+        _build_global_scopes.cache_clear()
         for t, kind, name in snaps:
             t.kind, t.name = kind, name
 
@@ -2960,4 +2966,46 @@ class TestConfigurableTypes:
         assert FwSizeStoreType.kind == TypeKind.U8
         assert FpyValue(string_type, "hi").serialize() == (
             FpyValue(U8, 2).serialize() + b"hi"
+        )
+
+    def test_custom_dictionary_redefines_types_end_to_end(self):
+        """A custom dictionary that redefines the Fw* aliases is picked up by the
+        full compile pipeline (_build_global_scopes), and directives serialize
+        accordingly."""
+        from fpy.compiler import _build_global_scopes
+        from fpy.bytecode.directives import (
+            FwOpcodeType,
+            FwChanIdType,
+            ConstCmdDirective,
+        )
+        from fpy.types import FwSizeStoreType
+
+        def _int_desc(name, size):
+            return {"name": name, "kind": "integer", "size": size, "signed": False}
+
+        # Start from the real dictionary so all the required types are present,
+        # then redefine the configurable aliases to non-default widths.
+        raw = json.loads(Path(REF_DICT_PATH).read_text())
+        overrides = {
+            "FwOpcodeType": _int_desc("U16", 16),
+            "FwChanIdType": _int_desc("U8", 8),
+            "FwSizeStoreType": _int_desc("U8", 8),
+        }
+        for td in raw["typeDefinitions"]:
+            new = overrides.get(td.get("qualifiedName"))
+            if new is not None:
+                td["type"] = new
+                td["underlyingType"] = new
+        path = _write_dict(raw)
+        try:
+            _build_global_scopes(path)
+        finally:
+            os.unlink(path)
+
+        assert FwOpcodeType.kind == TypeKind.U16
+        assert FwChanIdType.kind == TypeKind.U8
+        assert FwSizeStoreType.kind == TypeKind.U8
+        # FwPrmIdType was not overridden, so it keeps its default.
+        assert ConstCmdDirective(cmd_opcode=0xABCD, args=b"").serialize_args() == (
+            FpyValue(U16, 0xABCD).serialize()
         )

--- a/test/fpy/test_integration.py
+++ b/test/fpy/test_integration.py
@@ -185,13 +185,13 @@ CdhCore.cmdDisp.CMD_NO_OP_STRING(arg1="Hello world!")
 # Commands — flags.assert_cmd_success = False allows failing commands to proceed
 # README: flags.assert_cmd_success = False / CdhCore.exampleComponent.CMD_THAT_WILL_FAIL()
 flags.assert_cmd_success = False
-Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
 # sequence proceeds normally
 
 # Commands — handling the return value suppresses auto-assert
 # README: flags.assert_cmd_success = True / success = CdhCore.exampleComponent.CMD_THAT_WILL_FAIL()
 flags.assert_cmd_success = True
-success: Fw.CmdResponse = Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+success: Fw.CmdResponse = Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
 # cmd response is handled, sequence proceeds normally
 
 if success == Fw.CmdResponse.OK:
@@ -219,7 +219,7 @@ exit(0)
     def test_readme_bare_cmd_fail_exits(self, fprime_test_api):
         """README: CdhCore.exampleComponent.CMD_THAT_WILL_FAIL() / sequence exits with an error"""
         seq = """
-Ref.cmdSeq0.RUN("", Svc.FpySequencer.BlockState.NO_BLOCK)
+Ref.cmdSeq0.RUN("", Svc.BlockState.NO_BLOCK)
 # sequence exits with an error
 """
         assert_run_failure(

--- a/test/fpy/test_seq_calling.py
+++ b/test/fpy/test_seq_calling.py
@@ -94,7 +94,7 @@ CdhCore.cmdDisp.CMD_NO_OP()
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -113,7 +113,7 @@ assert x == 42
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 42)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 42)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -129,7 +129,7 @@ assert y == 7
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 100, 7)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 100, 7)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -145,7 +145,7 @@ assert val == 99
 
             parent_seq = f"""\
 my_val: U32 = 99
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, my_val)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, my_val)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -160,7 +160,7 @@ assert val == 30
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 10 + 20)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 10 + 20)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -176,7 +176,7 @@ assert result == 50
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 42)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 42)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -191,7 +191,7 @@ assert b == 255
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 255)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 255)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -207,7 +207,7 @@ assert f < 3.15
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 3.14)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 3.14)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -222,7 +222,7 @@ assert x == 999
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 1)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 1)
 """
             assert_run_failure(fprime_test_api, parent_seq, error_code=DirectiveErrorCode.CMD_FAIL, ground_binary_dir=tmpdir)
 
@@ -241,7 +241,7 @@ CdhCore.cmdDisp.CMD_NO_OP()
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 42)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 42)
 """
             assert_compile_failure(fprime_test_api, parent_seq, match="Missing required argument 'y'", ground_binary_dir=tmpdir)
 
@@ -256,7 +256,7 @@ CdhCore.cmdDisp.CMD_NO_OP()
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, true)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, true)
 """
             assert_compile_failure(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -265,7 +265,7 @@ Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, true)
         with tempfile.TemporaryDirectory() as tmpdir:
             fake_path = str(Path(tmpdir).resolve() / "nonexistent.bin")
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{fake_path}", Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS("{fake_path}", Svc.BlockState.BLOCK)
 """
             assert_compile_failure(fprime_test_api, parent_seq, match="not found", ground_binary_dir=tmpdir)
 
@@ -279,7 +279,7 @@ CdhCore.cmdDisp.CMD_NO_OP()
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK)
 """
             # No binary_dir passed
             assert_compile_failure(fprime_test_api, parent_seq, match="binary directory")
@@ -306,13 +306,13 @@ assert gc_val == 7
             child_seq = f"""\
 sequence(x: U32)
 assert x == 42
-Ref.seqDisp.RUN_ARGS("{grandchild_path}", Fw.Wait.WAIT, 7)
+Ref.seqDisp.RUN_ARGS("{grandchild_path}", Svc.BlockState.BLOCK, 7)
 """
             _compile_to_bin(child_seq, Path(child_path), ground_binary_dir=tmpdir)
 
             # Parent: calls child with an arg
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 42)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 42)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -332,12 +332,12 @@ assert val == 123
             child_seq = f"""\
 sequence(val: U32)
 assert val == 123
-Ref.seqDisp.RUN_ARGS("{grandchild_path}", Fw.Wait.WAIT, val)
+Ref.seqDisp.RUN_ARGS("{grandchild_path}", Svc.BlockState.BLOCK, val)
 """
             _compile_to_bin(child_seq, Path(child_path), ground_binary_dir=tmpdir)
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 123)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 123)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -357,7 +357,7 @@ CdhCore.cmdDisp.CMD_NO_OP()
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-resp: Fw.CmdResponse = Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT)
+resp: Fw.CmdResponse = Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK)
 if resp == Fw.CmdResponse.OK:
     exit(0)
 exit(1)
@@ -376,7 +376,7 @@ assert 1 == 0
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-resp: Fw.CmdResponse = Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT)
+resp: Fw.CmdResponse = Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK)
 if resp == Fw.CmdResponse.EXECUTION_ERROR:
     exit(0)
 exit(1)
@@ -396,7 +396,7 @@ assert x == 42
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-resp: Fw.CmdResponse = Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 42)
+resp: Fw.CmdResponse = Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 42)
 if resp == Fw.CmdResponse.OK:
     exit(0)
 exit(1)
@@ -416,7 +416,7 @@ assert x == 999
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-resp: Fw.CmdResponse = Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 1)
+resp: Fw.CmdResponse = Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 1)
 if resp == Fw.CmdResponse.EXECUTION_ERROR:
     exit(0)
 exit(1)
@@ -440,7 +440,7 @@ assert x == 42
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, x=42)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, x=42)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -458,7 +458,7 @@ assert b == 7
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, a=100, b=7)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, a=100, b=7)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -476,7 +476,7 @@ assert second == 2
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, second=2, first=1)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, second=2, first=1)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -495,7 +495,7 @@ assert c == 30
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 10, c=30, b=20)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 10, c=30, b=20)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -513,7 +513,7 @@ assert val == 55
 
             parent_seq = f"""\
 val: U32 = 55
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, val=val)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, val=val)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -530,7 +530,7 @@ assert result == 30
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, result=10 + 20)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, result=10 + 20)
 """
             assert_run_success(fprime_test_api, parent_seq, ground_binary_dir=tmpdir)
 
@@ -551,7 +551,7 @@ CdhCore.cmdDisp.CMD_NO_OP()
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, z=42)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, z=42)
 """
             assert_compile_failure(fprime_test_api, parent_seq, match="Unknown argument 'z'", ground_binary_dir=tmpdir)
 
@@ -568,7 +568,7 @@ CdhCore.cmdDisp.CMD_NO_OP()
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, x=1, x=2)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, x=1, x=2)
 """
             assert_compile_failure(fprime_test_api, parent_seq, match="specified multiple times", ground_binary_dir=tmpdir)
 
@@ -585,7 +585,7 @@ CdhCore.cmdDisp.CMD_NO_OP()
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, 42, x=99)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, 42, x=99)
 """
             assert_compile_failure(fprime_test_api, parent_seq, match="specified multiple times", ground_binary_dir=tmpdir)
 
@@ -602,7 +602,7 @@ CdhCore.cmdDisp.CMD_NO_OP()
             _compile_to_bin(child_seq, Path(child_path))
 
             parent_seq = f"""\
-Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, x=42)
+Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, x=42)
 """
             assert_compile_failure(fprime_test_api, parent_seq, match="Missing required argument 'y'", ground_binary_dir=tmpdir)
 
@@ -716,7 +716,7 @@ class TestSeqArgsBufferSizeFromDictionary:
             Path(child_path).write_bytes(data)
 
             args = ", ".join("0" for _ in range(10))
-            parent_seq = f'Ref.seqDisp.RUN_ARGS("{child_path}", Fw.Wait.WAIT, {args})\n'
+            parent_seq = f'Ref.seqDisp.RUN_ARGS("{child_path}", Svc.BlockState.BLOCK, {args})\n'
             body = text_to_ast(parent_seq)
             assert body is not None
             result = ast_to_directives(body, dict_path, ground_binary_dir=tmpdir)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

* Update to latest dict
* Load Fw type aliases from dict
* Fix all UTs and run with fprime-fpy-testbed
* 2 byte size prefix for arg name and type strs
* Canonical Svc.BlockState type