### PR TITLE
Check timeout relative instead of absolute

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -1,0 +1,3 @@
+* time base change while sequence is running
+* overflows, truncations
+* tlm/prm not found

--- a/README.md
+++ b/README.md
@@ -293,15 +293,15 @@ check CdhCore.cmdDisp.CommandsDispatched > 30 persist {seconds: 15}:
 
 If you don't specify a value for `persist`, the condition only has to be true once.
 
-You can specify an absolute time at which the `check` should time out:
+You can specify a `timeout`: a `Fw.TimeInterval` duration, measured from when the `check` is entered, after which the `check` gives up:
 ```py
-check CdhCore.cmdDisp.CommandsDispatched > 30 timeout now() + {seconds: 60} persist {seconds: 2}:
+check CdhCore.cmdDisp.CommandsDispatched > 30 timeout {seconds: 60} persist {seconds: 2}:
     log("more than 30 commands for 2 seconds!")
 ```
 
-You can also specify a `timeout` clause, which executes if the `check` times out:
+You can also specify a `timeout:` body, which executes if the `check` times out:
 ```py
-check CdhCore.cmdDisp.CommandsDispatched > 30 timeout now() + {seconds: 60} persist {seconds: 2}:
+check CdhCore.cmdDisp.CommandsDispatched > 30 timeout {seconds: 60} persist {seconds: 2}:
     log("more than 30 commands for 2 seconds!")
 timeout:
     log("took more than 60 seconds :(")
@@ -318,7 +318,7 @@ If you don't specify a value for `period`, the default period is 1 second.
 The `timeout`, `persist` and `period` clauses can appear in any order. They can also be spread across multiple lines:
 ```py
 check CdhCore.cmdDisp.CommandsDispatched > 30
-    timeout now() + {seconds: 60}
+    timeout {seconds: 60}
     persist {seconds: 2}
     period {seconds: 1}
     log("more than 30 commands for 2 seconds!")
@@ -328,7 +328,7 @@ timeout:
 
 If you just want to wait until a condition is true without running any body, you can omit the colon and body:
 ```py
-check CdhCore.cmdDisp.CommandsDispatched > 30 timeout now() + {seconds: 60}
+check CdhCore.cmdDisp.CommandsDispatched > 30 timeout {seconds: 60}
 # execution continues here once the condition is satisfied (or times out)
 log("done waiting!")
 ```

--- a/src/fpy/desugaring.py
+++ b/src/fpy/desugaring.py
@@ -344,18 +344,23 @@ class DesugarCheckStatements(Transformer):
     The generated AST nodes will go through normal semantic analysis.
     
     A check statement:
-        check <condition> [timeout <timeout>] [persist <persist>] [period <period>]:
+        check <condition> [timeout <interval>] [persist <persist>] [period <period>]:
             <body>
         [timeout:
             <timeout_body>]
-    
+
+    <interval>, <persist> and <period> are all relative Fw.TimeIntervalValue.
+    The timeout is a duration measured from the moment the check is entered.
+    To time out at an absolute deadline T, write the interval as (T - now()).
+
     Default values:
         - timeout: no timeout (runs indefinitely until condition persists)
         - persist: 0 second interval (condition must be true once)
         - period: 1 second interval (check condition every second)
-    
+
     Gets desugared into (roughly):
-        $check_state: $CheckState = $CheckState(...)
+        # timeout deadline computed once, at entry, from the relative interval:
+        $check_state: $CheckState = $CheckState(timeout=time_add(now(), <interval>), ...)
         while True:
             $current_time: Fw.Time = now()
             # If timeout is specified:
@@ -485,10 +490,15 @@ class DesugarCheckStatements(Transformer):
             else self.call_parts(["Fw", "TimeIntervalValue"], self.number(1), self.number(0))
         )
         
-        # For timeout, the expression must be Fw.Time (absolute time).
+        # The user supplies the timeout as a relative Fw.TimeIntervalValue.
+        # We turn it into an absolute deadline once, here at entry, as
+        # time_add(now(), <interval>). The deadline inherits now()'s timebase,
+        # so the per-iteration time_cmp(now(), deadline) is always comparable.
         # If no timeout specified, use a dummy value (the timeout check will be skipped anyway)
         if has_timeout:
-            timeout_expr_to_use = copy.deepcopy(node.timeout)
+            timeout_expr_to_use = self.call(
+                "time_add", self.call("now"), copy.deepcopy(node.timeout)
+            )
         else:
             # Dummy timeout value - won't be used since we skip timeout checks
             timeout_expr_to_use = self.call_parts(

--- a/test/fpy/golden/check_simple.fpy
+++ b/test/fpy/golden/check_simple.fpy
@@ -1,2 +1,2 @@
-check True timeout Fw.Time(TimeBase.TB_NONE, 0, 1, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 100000):
+check True timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 100000):
     pass

--- a/test/fpy/golden/check_simple.fpybc
+++ b/test/fpy/golden/check_simple.fpybc
@@ -1,4 +1,4 @@
-goto 160
+goto 222
 allocate 16
 load_rel -30 11
 push_val 0 0 0 0
@@ -158,10 +158,75 @@ push_val 0 0 0 0 0 15 66 64
 umod
 itrunc_64_32
 return 8 22
+allocate 32
+load_rel -27 11
+push_val 0 0 0 3
+get_field 11 4
+ziext_32_64
+push_val 0 0 0 0 0 15 66 64
+mul
+load_rel -27 11
+push_val 0 0 0 7
+get_field 11 4
+ziext_32_64
+add
+store_rel_const_offset 0 8
+load_rel -16 8
+push_val 0 0 0 0
+get_field 8 4
+ziext_32_64
+push_val 0 0 0 0 0 15 66 64
+mul
+load_rel -16 8
+push_val 0 0 0 4
+get_field 8 4
+ziext_32_64
+add
+store_rel_const_offset 8 8
+push_val 255 255 255 255 255 255 255 255
+load_rel 0 8
+sub
+load_rel 8 8
+uge
+not
+if 194
+push_val 1
+exit
+load_rel 0 8
+load_rel 8 8
+add
+store_rel_const_offset 16 8
+load_rel 16 8
+push_val 0 0 0 0 0 15 66 64
+udiv
+store_rel_const_offset 24 8
+load_rel 24 8
+push_val 0 0 0 0 255 255 255 255
+ule
+not
+if 209
+push_val 1
+exit
+load_rel -27 11
+push_val 0 0 0 0
+get_field 11 2
+load_rel -27 11
+push_val 0 0 0 2
+get_field 11 1
+load_rel 24 8
+itrunc_64_32
+load_rel 16 8
+push_val 0 0 0 0 0 15 66 64
+umod
+itrunc_64_32
+return 11 19
 push_val 255
 allocate 70
 push_val 0 0 0 0 0 0 0 0
-push_val 0 0 0 0 0 0 1 0 0 0 0
+push_time
+push_val 0 0 0 1 0 0 0 0
+push_val 0 0 0 160
+call
 push_val 0 0 0 0 0 1 134 160
 push_val 0
 push_val 0
@@ -169,7 +234,7 @@ push_val 0 0 0 0 0 0 0 0 0 0 0
 push_time
 store_rel_const_offset 1 51
 push_val 255
-if 248
+if 313
 push_time
 store_rel_const_offset 52 11
 load_rel 52 11
@@ -184,27 +249,27 @@ push_val 0 0 0 2
 memcmp 4
 not
 not
-if 189
+if 254
 push_val 1
 exit
 load_rel 63 4
 push_val 0 0 0 1
 memcmp 4
-if 195
-goto 248
-goto 195
+if 260
+goto 313
+goto 260
 push_val 255
-if 234
+if 299
 load_rel 1 51
 push_val 0 0 0 28
 get_field 51 1
 not
-if 207
+if 272
 load_rel 52 11
 store_rel_const_offset 30 11
 push_val 255
 store_rel_const_offset 29 1
-goto 207
+goto 272
 load_rel 52 11
 load_rel 1 51
 push_val 0 0 0 29
@@ -220,18 +285,18 @@ store_rel_const_offset 67 4
 load_rel 67 4
 push_val 0 0 0 1
 memcmp 4
-if 225
+if 290
 push_val 255
-goto 228
+goto 293
 load_rel 67 4
 push_val 0 0 0 0
 memcmp 4
-if 233
+if 298
 push_val 255
 store_rel_const_offset 28 1
-goto 248
-goto 233
-goto 236
+goto 313
+goto 298
+goto 301
 push_val 0
 store_rel_const_offset 29 1
 load_rel 1 51
@@ -245,9 +310,9 @@ get_field 51 8
 push_val 0 0 0 4
 get_field 8 4
 wait_rel
-goto 170
+goto 235
 load_rel 1 51
 push_val 0 0 0 27
 get_field 51 1
-if 253
-goto 253
+if 318
+goto 318

--- a/test/fpy/test_anon_exprs.py
+++ b/test/fpy/test_anon_exprs.py
@@ -291,7 +291,7 @@ class TestAnonExprInCheck:
         """Anon struct for the persist clause."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist {seconds: 0, useconds: 0} period Fw.TimeIntervalValue(0, 100000):
+check True timeout Fw.TimeIntervalValue(1, 0) persist {seconds: 0, useconds: 0} period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 timeout:
     assert False, 1
@@ -304,7 +304,7 @@ assert check_passed
         """Anon struct for the period clause."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period {seconds: 0, useconds: 100000}:
+check True timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period {seconds: 0, useconds: 100000}:
     check_passed = True
 timeout:
     assert False, 1
@@ -316,7 +316,7 @@ assert check_passed
         """Anon struct for the timeout clause (as TimeIntervalValue added to now())."""
         seq = """
 timed_out: bool = False
-check False timeout now() + {seconds: 0, useconds: 100000} persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check False timeout {seconds: 0, useconds: 100000} persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     assert False, 1
 timeout:
     timed_out = True
@@ -328,7 +328,7 @@ assert timed_out
         """All three clauses use anon struct syntax simultaneously."""
         seq = """
 check_passed: bool = False
-check True timeout now() + {seconds: 1, useconds: 0} persist {seconds: 0, useconds: 0} period {seconds: 0, useconds: 100000}:
+check True timeout {seconds: 1, useconds: 0} persist {seconds: 0, useconds: 0} period {seconds: 0, useconds: 100000}:
     check_passed = True
 timeout:
     assert False, 1
@@ -340,7 +340,7 @@ assert check_passed
         """Anon struct with defaults for persist (empty → {seconds:0, useconds:0})."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist {} period Fw.TimeIntervalValue(0, 100000):
+check True timeout Fw.TimeIntervalValue(1, 0) persist {} period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 timeout:
     assert False, 1
@@ -352,7 +352,7 @@ assert check_passed
         """Anon struct with partial members for period (useconds only, seconds defaults to 0)."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period {useconds: 100000}:
+check True timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period {useconds: 100000}:
     check_passed = True
 timeout:
     assert False, 1

--- a/test/fpy/test_check.py
+++ b/test/fpy/test_check.py
@@ -7,7 +7,7 @@ class TestCheckBehavior:
         """Test that check succeeds immediately when condition is true with zero persist."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 100000):
+check True timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 timeout:
     assert False, 1
@@ -19,7 +19,7 @@ assert check_passed
         """Test that check times out when condition is always false."""
         seq = """
 timed_out: bool = False
-check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check False timeout Fw.TimeIntervalValue(0, 100000) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     assert False, 1
 timeout:
     timed_out = True
@@ -38,7 +38,7 @@ def check_condition() -> bool:
     # Return true on 3rd evaluation
     return eval_count >= 3
 
-check check_condition() timeout time_add(now(), Fw.TimeIntervalValue(5, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check check_condition() timeout Fw.TimeIntervalValue(5, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     pass
 timeout:
     assert False, 1
@@ -68,7 +68,7 @@ def flaky_condition() -> bool:
 
 # Calls 1-2 are true but call 3 is false, resetting the persist timer
 # Call 4+ are true, so it should eventually succeed
-check flaky_condition() timeout time_add(now(), Fw.TimeIntervalValue(10, 0)) persist Fw.TimeIntervalValue(3, 0) period Fw.TimeIntervalValue(1, 0):
+check flaky_condition() timeout Fw.TimeIntervalValue(10, 0) persist Fw.TimeIntervalValue(3, 0) period Fw.TimeIntervalValue(1, 0):
     pass
 timeout:
     assert False, 1
@@ -90,7 +90,7 @@ def return_true_once() -> bool:
         return True
     return False
 
-check return_true_once() timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check return_true_once() timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     exit(0)
 timeout:
     assert False, 1
@@ -103,7 +103,7 @@ class TestCheckBodies:
         """Test that check body runs when condition succeeds."""
         seq = """
 body_ran: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check True timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     body_ran = True
 assert body_ran
 """
@@ -113,7 +113,7 @@ assert body_ran
         """Test that timeout body runs when check times out."""
         seq = """
 timeout_body_ran: bool = False
-check False timeout time_add(now(), Fw.TimeIntervalValue(0, 50000)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check False timeout Fw.TimeIntervalValue(0, 50000) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     assert False, 1
 timeout:
     timeout_body_ran = True
@@ -141,7 +141,7 @@ check eventually_true():
     def test_check_only_timeout_specified(self, fprime_test_api):
         """Test check with only timeout specified (uses default persist=0 and period=1s)."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+check True timeout Fw.TimeIntervalValue(1, 0):
     exit(0)
 timeout:
     assert False, 1
@@ -149,12 +149,14 @@ timeout:
         assert_run_success(fprime_test_api, seq)
 
     def test_check_absolute_timeout(self, fprime_test_api):
-        """Test that check works with absolute Fw.Time timeout."""
+        """Test timing out at an absolute deadline, expressed relative as (T - now())."""
         seq = """
-# Create an absolute timeout 100ms from now
+# An absolute deadline 100ms from now; converted to a relative interval
+# by subtracting now(). This is how an absolute timeout is expressed now
+# that the timeout clause takes a relative Fw.TimeIntervalValue.
 abs_timeout: Fw.Time = time_add(now(), Fw.TimeIntervalValue(0, 100000))
 result: bool = False
-check True timeout abs_timeout persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check True timeout (abs_timeout - now()) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     result = True
 timeout:
     pass
@@ -169,7 +171,7 @@ class TestCheckNesting:
         seq = """
 def do_check() -> bool:
     result: bool = False
-    check True timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+    check True timeout Fw.TimeIntervalValue(0, 100000) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
         result = True
     timeout:
         pass
@@ -184,7 +186,7 @@ assert do_check()
         seq = """
 outer_var: I32 = 0
 
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check True timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     outer_var = 42
 
 assert outer_var == 42
@@ -197,9 +199,9 @@ assert outer_var == 42
 outer_passed: bool = False
 inner_passed: bool = False
 
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+check True timeout Fw.TimeIntervalValue(1, 0):
     outer_passed = True
-    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    check True timeout Fw.TimeIntervalValue(1, 0):
         inner_passed = True
 
 assert outer_passed
@@ -213,9 +215,9 @@ assert inner_passed
 outer_passed: bool = False
 inner_timed_out: bool = False
 
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+check True timeout Fw.TimeIntervalValue(1, 0):
     outer_passed = True
-    check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) period Fw.TimeIntervalValue(0, 10000):
+    check False timeout Fw.TimeIntervalValue(0, 100000) period Fw.TimeIntervalValue(0, 10000):
         pass
     timeout:
         inner_timed_out = True
@@ -232,7 +234,7 @@ iterations: I64 = 0
 checks_passed: I64 = 0
 
 while iterations < 3:
-    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    check True timeout Fw.TimeIntervalValue(1, 0):
         checks_passed = checks_passed + 1
     iterations = iterations + 1
 
@@ -247,7 +249,7 @@ assert checks_passed == 3
 checks_passed: I64 = 0
 
 for i in 0..3:
-    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    check True timeout Fw.TimeIntervalValue(1, 0):
         checks_passed = checks_passed + 1
 
 assert checks_passed == 3
@@ -267,7 +269,7 @@ check True timeout 123 persist Fw.TimeIntervalValue(0, 0) period Fw.TimeInterval
     def test_check_condition_wrong_type(self, fprime_test_api):
         """Test that check condition must be bool, not int."""
         seq = """
-check 123 timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check 123 timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -275,7 +277,7 @@ check 123 timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeInt
     def test_check_condition_wrong_type_string(self, fprime_test_api):
         """Test that check condition must be bool, not string."""
         seq = """
-check "hello" timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check "hello" timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -283,7 +285,7 @@ check "hello" timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.Tim
     def test_check_persist_wrong_type(self, fprime_test_api):
         """Test that check persist must be TimeIntervalValue, not int."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist 123 period Fw.TimeIntervalValue(0, 10000):
+check True timeout Fw.TimeIntervalValue(1, 0) persist 123 period Fw.TimeIntervalValue(0, 10000):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -291,7 +293,7 @@ check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist 123 perio
     def test_check_persist_wrong_type_time(self, fprime_test_api):
         """Test that check persist must be TimeIntervalValue, not Fw.Time."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist now() period Fw.TimeIntervalValue(0, 10000):
+check True timeout Fw.TimeIntervalValue(1, 0) persist now() period Fw.TimeIntervalValue(0, 10000):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -299,7 +301,7 @@ check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist now() per
     def test_check_freq_wrong_type(self, fprime_test_api):
         """Test that check period must be TimeIntervalValue, not int."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period 123:
+check True timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period 123:
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -307,7 +309,7 @@ check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIn
     def test_check_freq_wrong_type_time(self, fprime_test_api):
         """Test that check period must be TimeIntervalValue, not Fw.Time."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period now():
+check True timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period now():
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -317,7 +319,7 @@ class TestCheckDuplicateClauses:
     def test_check_duplicate_timeout(self, fprime_test_api):
         """Test that duplicate timeout clauses cause a compile error."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) timeout time_add(now(), Fw.TimeIntervalValue(2, 0)):
+check True timeout Fw.TimeIntervalValue(1, 0) timeout Fw.TimeIntervalValue(2, 0):
     pass
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -345,7 +347,7 @@ class TestCheckMultilineSyntax:
         seq = """
 check_passed: bool = False
 check True
-    timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    timeout Fw.TimeIntervalValue(1, 0):
     check_passed = True
 timeout:
     assert False, 1
@@ -358,7 +360,7 @@ assert check_passed
         seq = """
 check_passed: bool = False
 check True
-    timeout time_add(now(), Fw.TimeIntervalValue(1, 0))
+    timeout Fw.TimeIntervalValue(1, 0)
     persist Fw.TimeIntervalValue(0, 0)
     period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
@@ -375,7 +377,7 @@ check_passed: bool = False
 check True
     period Fw.TimeIntervalValue(0, 100000)
     persist Fw.TimeIntervalValue(0, 0)
-    timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    timeout Fw.TimeIntervalValue(1, 0):
     check_passed = True
 timeout:
     assert False, 1
@@ -389,7 +391,7 @@ assert check_passed
 check_passed: bool = False
 check True
     persist Fw.TimeIntervalValue(0, 0)
-    timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    timeout Fw.TimeIntervalValue(1, 0):
     check_passed = True
 timeout:
     assert False, 1
@@ -401,7 +403,7 @@ assert check_passed
         """Test single-line check with persist before timeout."""
         seq = """
 check_passed: bool = False
-check True persist Fw.TimeIntervalValue(0, 0) timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+check True persist Fw.TimeIntervalValue(0, 0) timeout Fw.TimeIntervalValue(1, 0):
     check_passed = True
 timeout:
     assert False, 1
@@ -413,7 +415,7 @@ assert check_passed
         """Test single-line check with period before other clauses."""
         seq = """
 check_passed: bool = False
-check True period Fw.TimeIntervalValue(0, 100000) persist Fw.TimeIntervalValue(0, 0) timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+check True period Fw.TimeIntervalValue(0, 100000) persist Fw.TimeIntervalValue(0, 0) timeout Fw.TimeIntervalValue(1, 0):
     check_passed = True
 timeout:
     assert False, 1
@@ -446,7 +448,7 @@ assert check_passed
         seq = """
 timed_out: bool = False
 check False
-    timeout time_add(now(), Fw.TimeIntervalValue(0, 100000))
+    timeout Fw.TimeIntervalValue(0, 100000)
     period Fw.TimeIntervalValue(0, 10000):
     assert False, 1
 timeout:
@@ -459,7 +461,7 @@ assert timed_out
         """Test check with some clauses inline and some on indented lines."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0))
+check True timeout Fw.TimeIntervalValue(1, 0)
     persist Fw.TimeIntervalValue(0, 0)
     period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
@@ -473,7 +475,7 @@ assert check_passed
         """Test check with two clauses inline and one on indented line."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0)
+check True timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0)
     period Fw.TimeIntervalValue(0, 100000):
     check_passed = True
 timeout:
@@ -487,7 +489,7 @@ class TestCheckControlFlow:
     def test_check_break_not_allowed(self, fprime_test_api):
         """Test that break inside check body is not allowed when check is not in a loop."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+check True timeout Fw.TimeIntervalValue(1, 0):
     break
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -495,7 +497,7 @@ check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
     def test_check_continue_not_allowed(self, fprime_test_api):
         """Test that continue inside check body is not allowed when check is not in a loop."""
         seq = """
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+check True timeout Fw.TimeIntervalValue(1, 0):
     continue
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -505,7 +507,7 @@ check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
         seq = """
 loop_ran: bool = False
 while True:
-    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    check True timeout Fw.TimeIntervalValue(1, 0):
         loop_ran = True
         break
 assert loop_ran
@@ -518,7 +520,7 @@ assert loop_ran
 iterations: I64 = 0
 while iterations < 3:
     iterations = iterations + 1
-    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    check True timeout Fw.TimeIntervalValue(1, 0):
         continue
 assert iterations == 3
 """
@@ -528,7 +530,7 @@ assert iterations == 3
         """Test that return inside check body works correctly in a function."""
         seq = """
 def check_and_return() -> I64:
-    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    check True timeout Fw.TimeIntervalValue(1, 0):
         return 42
     return 0
 
@@ -541,7 +543,7 @@ assert result == 42
         """Test that return from timeout body works correctly."""
         seq = """
 def check_timeout_return() -> I64:
-    check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) period Fw.TimeIntervalValue(0, 10000):
+    check False timeout Fw.TimeIntervalValue(0, 100000) period Fw.TimeIntervalValue(0, 10000):
         return 1
     timeout:
         return 42
@@ -556,7 +558,7 @@ assert result == 42
         """Test that a function with check where both bodies return doesn't need trailing return."""
         seq = """
 def check_returns() -> I64:
-    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    check True timeout Fw.TimeIntervalValue(1, 0):
         return 42
     timeout:
         return 0
@@ -570,7 +572,7 @@ assert result == 42
         """Test that a function with check but no timeout body still needs trailing return."""
         seq = """
 def check_needs_return() -> I64:
-    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)):
+    check True timeout Fw.TimeIntervalValue(1, 0):
         return 42
 """
         assert_compile_failure(fprime_test_api, seq)
@@ -594,7 +596,7 @@ class TestBodylessCheck:
         """Body-less check with True condition proceeds immediately."""
         seq = """
 done: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) period Fw.TimeIntervalValue(0, 100000)
+check True timeout Fw.TimeIntervalValue(1, 0) period Fw.TimeIntervalValue(0, 100000)
 done = True
 assert done
 """
@@ -603,7 +605,7 @@ assert done
     def test_bodyless_check_inline_with_timeout(self, fprime_test_api):
         """Body-less check that times out (no timeout body, just proceeds)."""
         seq = """
-check False timeout time_add(now(), Fw.TimeIntervalValue(0, 50000)) period Fw.TimeIntervalValue(0, 10000)
+check False timeout Fw.TimeIntervalValue(0, 50000) period Fw.TimeIntervalValue(0, 10000)
 """
         assert_run_success(fprime_test_api, seq)
 
@@ -621,7 +623,7 @@ assert done
         """Body-less check with only a timeout clause."""
         seq = """
 done: bool = False
-check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0))
+check True timeout Fw.TimeIntervalValue(1, 0)
 done = True
 assert done
 """
@@ -642,7 +644,7 @@ assert done
         seq = """
 done: bool = False
 check True
-    timeout time_add(now(), Fw.TimeIntervalValue(1, 0))
+    timeout Fw.TimeIntervalValue(1, 0)
     period Fw.TimeIntervalValue(0, 100000)
 done = True
 assert done
@@ -654,7 +656,7 @@ assert done
         seq = """
 timed_out: bool = False
 check False
-    timeout time_add(now(), Fw.TimeIntervalValue(0, 50000))
+    timeout Fw.TimeIntervalValue(0, 50000)
     period Fw.TimeIntervalValue(0, 10000)
 timeout:
     timed_out = True
@@ -670,7 +672,7 @@ def counting_condition() -> bool:
     counter = counter + 1
     return counter >= 3
 
-check counting_condition() timeout time_add(now(), Fw.TimeIntervalValue(5, 0)) period Fw.TimeIntervalValue(0, 10000)
+check counting_condition() timeout Fw.TimeIntervalValue(5, 0) period Fw.TimeIntervalValue(0, 10000)
 assert counter >= 3
 """
         assert_run_success(fprime_test_api, seq)
@@ -680,7 +682,7 @@ assert counter >= 3
         seq = """
 done: bool = False
 if True:
-    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) period Fw.TimeIntervalValue(0, 100000)
+    check True timeout Fw.TimeIntervalValue(1, 0) period Fw.TimeIntervalValue(0, 100000)
     done = True
 assert done
 """
@@ -690,7 +692,7 @@ assert done
         """Body-less check inside a function, followed by more statements."""
         seq = """
 def wait_and_return() -> I64:
-    check True timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) period Fw.TimeIntervalValue(0, 100000)
+    check True timeout Fw.TimeIntervalValue(1, 0) period Fw.TimeIntervalValue(0, 100000)
     return 42
 
 result: I64 = wait_and_return()

--- a/test/fpy/test_integration.py
+++ b/test/fpy/test_integration.py
@@ -142,23 +142,23 @@ recurse(5) # prints "tick" 5 times
 
 check CdhCore.cmdDisp.CommandsDispatched > 1 persist {seconds: 1}:
     log("more than 30 commands for 15 seconds!")
-check CdhCore.cmdDisp.CommandsDispatched > 1 timeout now() + {seconds: 60} persist {seconds: 1}:
+check CdhCore.cmdDisp.CommandsDispatched > 1 timeout {seconds: 60} persist {seconds: 1}:
     log("more than 30 commands for 2 seconds!")
-check CdhCore.cmdDisp.CommandsDispatched > 1 timeout now() + {seconds: 60} persist {seconds: 1}:
+check CdhCore.cmdDisp.CommandsDispatched > 1 timeout {seconds: 60} persist {seconds: 1}:
     log("more than 30 commands for 2 seconds!")
 timeout:
     log("took more than 60 seconds :(")
 check CdhCore.cmdDisp.CommandsDispatched > 1 period {seconds: 1}: # check every 1 second
     log("more than 30 commands!")
 check CdhCore.cmdDisp.CommandsDispatched > 1
-    timeout now() + {seconds: 60}
+    timeout {seconds: 60}
     persist {seconds: 1}
     period {seconds: 1}:
     log("more than 30 commands for 2 seconds!")
 timeout:
     log("took more than 60 seconds :(")
 
-check CdhCore.cmdDisp.CommandsDispatched > 1 timeout now() + {seconds: 60}
+check CdhCore.cmdDisp.CommandsDispatched > 1 timeout {seconds: 60}
 log("done waiting!")
 
 # Time functions examples

--- a/test/fpy/test_parsing.py
+++ b/test/fpy/test_parsing.py
@@ -271,12 +271,12 @@ assert x == 30
         """Nested multi-line expressions with braces inside parens."""
         seq = """
 check_passed: bool = False
-check True timeout time_add(
-    now(),
+check True timeout time_interval_add(
     {
         seconds: 1,
         useconds: 0,
     },
+    {seconds: 0, useconds: 0},
 ) persist {seconds: 0, useconds: 0} period {seconds: 0, useconds: 100000}:
     check_passed = True
 timeout:
@@ -289,7 +289,7 @@ assert check_passed
         """Check statement with multi-line anon struct in timeout position."""
         seq = """
 check_passed: bool = False
-check True timeout now() + {
+check True timeout {
     seconds: 1,
     useconds: 0,
 } persist {

--- a/test/fpy/test_time_seqs.py
+++ b/test/fpy/test_time_seqs.py
@@ -1013,26 +1013,6 @@ assert result == Fw.TimeComparison.LT  # t1 < t2
 """
         assert_run_success(fprime_test_api, seq)
 
-    def test_check_with_different_time_base_crashes(self, fprime_test_api):
-        """Test that check crashes when now() and timeout have different time_bases.
-
-        This tests the full check statement integration: the check desugars to use
-        time_cmp(now(), timeout), and if the time_bases differ, the assert should crash.
-        """
-        seq = """
-# Construct a timeout with a different timeBase than what now() returns
-# now() returns timeBase=TimeBase.TB_NONE by default
-# Set timeout with timeBase=TimeBase.TB_PROC_TIME
-bad_timeout: Fw.Time = Fw.Time(TimeBase.TB_PROC_TIME, 0, 100, 0)
-
-check True timeout bad_timeout persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 100000):
-    pass
-timeout:
-    pass
-"""
-        # Now run with default timeBase=0, but the timeout uses timeBase=1
-        assert_run_failure(fprime_test_api, seq, DirectiveErrorCode.EXIT_WITH_ERROR)
-
     def test_check_with_simulated_time_timeout(self, fprime_test_api):
         """Test that check properly times out based on simulated time advancement.
 

--- a/test/fpy/test_time_seqs.py
+++ b/test/fpy/test_time_seqs.py
@@ -1046,7 +1046,7 @@ timed_out: bool = False
 
 # Set timeout to be 100ms from now
 # With period of 10ms, we'll check ~10 times before timeout
-check False timeout time_add(now(), Fw.TimeIntervalValue(0, 100000)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check False timeout Fw.TimeIntervalValue(0, 100000) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     # This shouldn't run because condition is always false
     assert False, 1
 timeout:
@@ -1074,7 +1074,7 @@ def condition() -> bool:
 
 # Require condition to persist for 50ms with 10ms frequency
 # Should need ~5 checks to persist
-check condition() timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 50000) period Fw.TimeIntervalValue(0, 10000):
+check condition() timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 50000) period Fw.TimeIntervalValue(0, 10000):
     pass
 timeout:
     assert False, 1
@@ -1117,7 +1117,7 @@ def check_time_base() -> bool:
         time_base_ok = False
     return check_count >= 3
 
-check check_time_base() timeout time_add(now(), Fw.TimeIntervalValue(1, 0)) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
+check check_time_base() timeout Fw.TimeIntervalValue(1, 0) persist Fw.TimeIntervalValue(0, 0) period Fw.TimeIntervalValue(0, 10000):
     pass
 timeout:
     assert False, 1


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #76 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

* Check timeout clause takes a Fw.TimeInterval instead of Fw.Time

## Rationale

* Fw.TimeInterval is the most common use case for timeout
* You can still time out at an absolute time by calculating the relative time diff between now and that time
