### PR TITLE
Finish support for time operator overriding in LLVM IR

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -120,6 +120,7 @@ Pythonically
 pyversions
 randf
 rb
+rsleep
 rustup
 SADMEP
 sdiv

--- a/src/fpy/codegen_llvm.py
+++ b/src/fpy/codegen_llvm.py
@@ -609,10 +609,19 @@ class EmitLlvmExpr(Emitter):
         elif is_instance_compat(func, BuiltinFuncSymbol):
             return self._emit_builtin_call(node_args, func, state)
         elif is_instance_compat(func, TypeCtorSymbol):
-            # A ctor call with all-constant args folds before reaching here.
-            raise BackendError(
-                "LLVM backend can't lower runtime type-constructor calls yet"
-            )
+            # A ctor call with all-constant args folds before reaching here;
+            # what remains builds the aggregate (struct or array) from its
+            # positional args, each already coerced to its member/element
+            # type. A filled-in default arrives as a bare FpyValue.
+            value = ir.Constant(func.type.llvm_type, ir.Undefined)
+            for i, arg in enumerate(node_args):
+                elem = (
+                    arg.llvm_value
+                    if is_instance_compat(arg, FpyValue)
+                    else self.emit(arg, state)
+                )
+                value = self.builder.insert_value(value, elem, i)
+            return value
         elif is_instance_compat(func, CastSymbol):
             # the actual conversion happens already as part of the
             # synthesized -> contextual conversion in emit()
@@ -897,8 +906,11 @@ class AssignAddresses(TopDownVisitor):
         ptrs = state.backend.variable_ptrs
         assert sym not in ptrs, sym
         if sym.is_global:
+            # Unique the name: a variable may share its name with a module-level
+            # symbol (e.g. a host import like "time").
+            module = state.backend.module
             gvar = ir.GlobalVariable(
-                state.backend.module, sym.type.llvm_type, name=sym.name
+                module, sym.type.llvm_type, name=module.get_unique_name(sym.name)
             )
             gvar.linkage = "internal"
             # Zero-initialized; the declaring assignment writes the real value.
@@ -1313,8 +1325,9 @@ class GenerateLlvmModule:
         It lives in the base scope, outside every block, so no storage walk
         reaches it."""
         flags = state.flags_var
+        module = state.backend.module
         g = ir.GlobalVariable(
-            state.backend.module, flags.type.llvm_type, name=flags.name
+            module, flags.type.llvm_type, name=module.get_unique_name(flags.name)
         )
         g.linkage = "internal"
         g.initializer = FpyValue(

--- a/src/fpy/macros.py
+++ b/src/fpy/macros.py
@@ -15,7 +15,13 @@ from fpy.bytecode.directives import (
 )
 from fpy.ir import Ir
 from fpy.symbols import BuiltinFuncSymbol
-from fpy.wasm_host import HOST_EVENT_FUNC_NAME, HOST_EXIT_FUNC_NAME
+from fpy.wasm_host import (
+    HOST_ASLEEP_FUNC_NAME,
+    HOST_EVENT_FUNC_NAME,
+    HOST_EXIT_FUNC_NAME,
+    HOST_RSLEEP_FUNC_NAME,
+    HOST_TIME_FUNC_NAME,
+)
 from fpy.syntax import Ast
 from fpy.bytecode.directives import SerialPortIndex
 from fpy.types import (
@@ -68,6 +74,68 @@ def generate_abs_signed_int(
     return [IntAbsDirective()]
 
 
+def _emit_micros_u64(builder, seconds, useconds):
+    """Combine a (seconds, useconds) pair of i32 values into one i64
+    microsecond count, the unit the host sleep imports take."""
+    from llvmlite import ir
+
+    i64 = ir.IntType(64)
+    return builder.add(
+        builder.mul(builder.zext(seconds, i64), ir.Constant(i64, 1_000_000)),
+        builder.zext(useconds, i64),
+    )
+
+
+def generate_now_llvm(builder, args):
+    """LLVM/wasm lowering of now(): the host time import writes the serialized
+    Fw.Time into a buffer in linear memory, which is then deserialized into
+    the Fw.Time value."""
+    from llvmlite import ir
+
+    # The load helper lives with the rest of the wire-format emission in the
+    # LLVM backend; import it here so this module stays importable without
+    # llvmlite.
+    from fpy.codegen_llvm import EmitLlvmExpr, create_byte_buffer
+
+    assert not args
+    module = builder.module
+    buf = create_byte_buffer(module, "time_buf", bytearray(TIME.max_size))
+    builder.call(
+        module.globals[HOST_TIME_FUNC_NAME],
+        [
+            builder.bitcast(buf, ir.IntType(8).as_pointer()),
+            ir.Constant(ir.IntType(32), TIME.max_size),
+        ],
+    )
+    return EmitLlvmExpr(builder)._emit_load_big_endian(TIME, buf, 0)
+
+
+def generate_sleep_llvm(builder, args):
+    """LLVM/wasm lowering of sleep(seconds, useconds): the host rsleep import
+    takes the duration as one microsecond count."""
+    [(seconds, _), (useconds, _)] = args
+    builder.call(
+        builder.module.globals[HOST_RSLEEP_FUNC_NAME],
+        [_emit_micros_u64(builder, seconds, useconds)],
+    )
+    return None
+
+
+def generate_sleep_until_llvm(builder, args):
+    """LLVM/wasm lowering of sleep_until(wakeup_time): the host asleep import
+    takes the wake-up time as microseconds since the epoch of the host's time
+    base (the wakeup time's own base and context do not travel)."""
+    [(wakeup, _)] = args
+    member_idx = {m.name: i for i, m in enumerate(TIME.members)}
+    seconds = builder.extract_value(wakeup, member_idx["seconds"])
+    useconds = builder.extract_value(wakeup, member_idx["useconds"])
+    builder.call(
+        builder.module.globals[HOST_ASLEEP_FUNC_NAME],
+        [_emit_micros_u64(builder, seconds, useconds)],
+    )
+    return None
+
+
 MACRO_SLEEP_SECONDS_USECONDS = BuiltinFuncSymbol(
     "sleep",
     NOTHING,
@@ -80,6 +148,7 @@ MACRO_SLEEP_SECONDS_USECONDS = BuiltinFuncSymbol(
         ("useconds", U32, FpyValue(U32, 0)),
     ],
     lambda n, c: [WaitRelDirective()],
+    generate_sleep_llvm,
 )
 
 
@@ -243,6 +312,7 @@ MACROS: dict[str, BuiltinFuncSymbol] = {
         NOTHING,
         [("wakeup_time", TIME, None)],
         lambda n, c: [WaitAbsDirective()],
+        generate_sleep_until_llvm,
     ),
     "exit": BuiltinFuncSymbol(
         "exit",
@@ -258,7 +328,9 @@ MACROS: dict[str, BuiltinFuncSymbol] = {
         lambda n, c: [FloatLogDirective()],
         generate_log_llvm,
     ),
-    "now": BuiltinFuncSymbol("now", TIME, [], lambda n, c: [PushTimeDirective()]),
+    "now": BuiltinFuncSymbol(
+        "now", TIME, [], lambda n, c: [PushTimeDirective()], generate_now_llvm
+    ),
     "rand": BuiltinFuncSymbol("rand", U32, [], lambda n, c: [PushRandDirective()]),
     "randf": BuiltinFuncSymbol("randf", F64, [], generate_randf),
     "set_seed": BuiltinFuncSymbol(

--- a/src/fpy/test_helpers.py
+++ b/src/fpy/test_helpers.py
@@ -158,6 +158,9 @@ def run_seq_wasm(
     failing_opcodes: set[int] = None,
     tlm: dict[str, bytes] = None,
     prms: dict[str, bytes] = None,
+    time_base: int = 0,
+    time_context: int = 0,
+    initial_time_us: int = 0,
 ) -> int:
     """Compile *seq* to wasm and run it, returning the sequence's error code
     (reported via the exit/panic host imports; 0 when the void entrypoint
@@ -176,6 +179,9 @@ def run_seq_wasm(
         failing_opcodes=failing_opcodes,
         tlm=tlm,
         prms=prms,
+        time_base=time_base,
+        time_context=time_context,
+        initial_time_us=initial_time_us,
     )
     return code
 
@@ -240,6 +246,9 @@ def _run_seq_wasm(
     cmd_response: int = None,
     tlm: dict[str, bytes] = None,
     prms: dict[str, bytes] = None,
+    time_base: int = 0,
+    time_context: int = 0,
+    initial_time_us: int = 0,
 ) -> tuple[int, list[tuple[int, str]], list[bytes]]:
     """Compile *seq* to wasm, run it through the spacewasm runner harness, and
     return (error code, reported events, dispatched command buffers).
@@ -260,6 +269,9 @@ def _run_seq_wasm(
         cmd_response=cmd_response,
         tlm=tlm,
         prms=prms,
+        time_base=time_base,
+        time_context=time_context,
+        initial_time_us=initial_time_us,
     )
 
 
@@ -269,6 +281,9 @@ def run_wasm(
     cmd_response: int = None,
     tlm: dict[str, bytes] = None,
     prms: dict[str, bytes] = None,
+    time_base: int = 0,
+    time_context: int = 0,
+    initial_time_us: int = 0,
 ) -> tuple[int, list[tuple[int, str]], list[bytes]]:
     """Run an already-linked wasm module on a real Svc::WasmSequencer through
     the wasm harness and return (error code, reported events, dispatched
@@ -288,7 +303,12 @@ def run_wasm(
     request = {
         "seqFile": seq_file,
         "cwd": seq_dir,
-        "time": {"base": 0, "context": 0, "seconds": 0, "useconds": 0},
+        "time": {
+            "base": time_base,
+            "context": time_context,
+            "seconds": initial_time_us // 1_000_000,
+            "useconds": initial_time_us % 1_000_000,
+        },
         "tlm": {
             str(d["ch_name_dict"][chan_name].ch_id): bytes(val).hex()
             for chan_name, val in (tlm or {}).items()
@@ -631,6 +651,9 @@ def assert_run_success(
             failing_opcodes=failing_opcodes,
             tlm=tlm,
             prms=prms,
+            time_base=time_base,
+            time_context=time_context,
+            initial_time_us=initial_time_us,
         )
         if code != DirectiveErrorCode.NO_ERROR.value:
             raise RuntimeError(f"wasm sequence returned error code {code}")
@@ -752,6 +775,7 @@ def assert_run_failure(
             ground_binary_dir=ground_binary_dir,
             import_directories=import_directories,
             failing_opcodes=failing_opcodes,
+            initial_time_us=initial_time_us,
         )
         if code == DirectiveErrorCode.NO_ERROR.value:
             raise RuntimeError("wasm sequence succeeded")

--- a/src/fpy/wasm_host.py
+++ b/src/fpy/wasm_host.py
@@ -19,6 +19,9 @@ HOST_EVENT_FUNC_NAME = "event"
 HOST_CMD_FUNC_NAME = "cmd"
 HOST_TLM_FUNC_NAME = "tlm"
 HOST_PRM_FUNC_NAME = "prm"
+HOST_TIME_FUNC_NAME = "time"
+HOST_RSLEEP_FUNC_NAME = "rsleep"
+HOST_ASLEEP_FUNC_NAME = "asleep"
 
 
 def __getattr__(name: str):
@@ -111,6 +114,27 @@ def declare_host_imports(module: ir.Module) -> None:
                 ir.IntType(32),
             ],
         ),
+    )
+
+    # time(time_ptr, time_len) reads the current time: the host writes the
+    # serialized Fw.Time into the buffer, whose length must be exactly the
+    # serialized time size.
+    _declare_host_func(
+        module,
+        HOST_TIME_FUNC_NAME,
+        ir.FunctionType(ir.VoidType(), [ir.IntType(8).as_pointer(), ir.IntType(32)]),
+    )
+
+    # rsleep(useconds) suspends the sequence for the given duration, relative
+    # to the current time.
+    _declare_host_func(
+        module, HOST_RSLEEP_FUNC_NAME, ir.FunctionType(ir.VoidType(), [ir.IntType(64)])
+    )
+
+    # asleep(useconds) suspends the sequence until the given absolute time,
+    # expressed in microseconds since the epoch of the host's time base.
+    _declare_host_func(
+        module, HOST_ASLEEP_FUNC_NAME, ir.FunctionType(ir.VoidType(), [ir.IntType(64)])
     )
 
     # prm(prm_id, buf_ptr, buf_len) reads a parameter: the host writes the


### PR DESCRIPTION
New in LLVM backend:
* Non-const type ctor calls
* now() func
* sleep
* sleep_until