### PR TITLE
Desguar anon exprs

### DIFF
--- a/src/fpy/PASSES.md
+++ b/src/fpy/PASSES.md
@@ -27,6 +27,10 @@ For each function definition statement:
 For each sequence metadata statement:
 1. If the number of parameters is greater than 255, raise an error.
 
+# CheckAnonStructMembers
+
+For each anonymous struct expression, if two of its members have the same name, raise an error.
+
 # DefineFunctions
 
 For each function definition statement:

--- a/src/fpy/codegen_fpybc.py
+++ b/src/fpy/codegen_fpybc.py
@@ -118,8 +118,6 @@ from fpy.bytecode.directives import (
 )
 from fpy.syntax import (
     Ast,
-    AstAnonStruct,
-    AstAnonArray,
     AstAssert,
     AstBinaryOp,
     AstBreak,
@@ -859,21 +857,6 @@ class GenerateFunctionBody(EmitterWithNodeInfo):
         # use the unconverted for this expr for now, because we haven't run conversion
         unconverted_type = state.synthesized_types[node]
 
-        if is_instance_compat(node.parent, AstAnonArray):
-            # Direct index access on anonymous array literal.
-            # The index must be a compile-time constant.
-            idx_value = state.const_expr_values.get(node.item)
-            assert (
-                idx_value is not None
-            ), "Dynamic indexing on anonymous array literals is not supported"
-            idx = idx_value.val
-            assert 0 <= idx < len(node.parent.elements), f"Index {idx} out of bounds"
-            dirs = self.emit(node.parent.elements[idx], state)
-            converted_type = state.contextual_types[node]
-            if unconverted_type != converted_type:
-                dirs.extend(self.convert_numeric_type(unconverted_type, converted_type))
-            return dirs
-
         # however, for parent, use converted because conversion has been run
         parent_type = state.contextual_types[node.parent]
 
@@ -960,30 +943,18 @@ class GenerateFunctionBody(EmitterWithNodeInfo):
         elif is_instance_compat(sym, PrmDef):
             dirs.append(PushPrmDirective(sym.prm_id))
         elif is_instance_compat(sym, FieldAccess):
-            if is_instance_compat(sym.parent_expr, AstAnonStruct):
-                # Direct member access on anonymous struct literal.
-                # Emit just the accessed member expression (skip the struct build).
-                for name, value_expr in sym.parent_expr.members:
-                    if name == node.attr:
-                        dirs.extend(self.emit(value_expr, state))
-                        break
-                else:
-                    assert False, f"Member {node.attr} not found in anon struct"
-            else:
-                # okay, put parent dirs in first
-                dirs.extend(self.emit(sym.parent_expr, state))
-                assert sym.local_offset is not None
-                # use the converted type of parent
-                parent_type = state.contextual_types[sym.parent_expr]
-                # push the offset to the stack
-                dirs.append(
-                    PushValDirective(
-                        FpyValue(StackSizeType, sym.local_offset).serialize()
-                    )
-                )
-                dirs.append(
-                    GetFieldDirective(parent_type.max_size, unconverted_type.max_size)
-                )
+            # okay, put parent dirs in first
+            dirs.extend(self.emit(sym.parent_expr, state))
+            assert sym.local_offset is not None
+            # use the converted type of parent
+            parent_type = state.contextual_types[sym.parent_expr]
+            # push the offset to the stack
+            dirs.append(
+                PushValDirective(FpyValue(StackSizeType, sym.local_offset).serialize())
+            )
+            dirs.append(
+                GetFieldDirective(parent_type.max_size, unconverted_type.max_size)
+            )
         else:
             assert (
                 False
@@ -1343,32 +1314,6 @@ class GenerateFunctionBody(EmitterWithNodeInfo):
         const_dirs = self.try_emit_expr_as_const(node, state)
         assert const_dirs is not None
         return const_dirs
-
-    def emit_AstAnonStruct(self, node: AstAnonStruct, state: CompileState):
-        # Try to emit as a constant first
-        const_dirs = self.try_emit_expr_as_const(node, state)
-        if const_dirs is not None:
-            return const_dirs
-
-        # Emit each resolved member value in target struct order
-        dirs = []
-        resolved_members = state.resolved_args[node]
-        for member_expr in resolved_members:
-            dirs.extend(self._emit_func_arg(member_expr, state))
-        return dirs
-
-    def emit_AstAnonArray(self, node: AstAnonArray, state: CompileState):
-        # Try to emit as a constant first
-        const_dirs = self.try_emit_expr_as_const(node, state)
-        if const_dirs is not None:
-            return const_dirs
-
-        # Emit each element value
-        dirs = []
-        resolved_elements = state.resolved_args[node]
-        for elem_expr in resolved_elements:
-            dirs.extend(self._emit_func_arg(elem_expr, state))
-        return dirs
 
     def emit_AstAssert(self, node: AstAssert, state: CompileState):
         dirs = self.emit(node.condition, state)

--- a/src/fpy/codegen_llvm.py
+++ b/src/fpy/codegen_llvm.py
@@ -32,8 +32,6 @@ from fpy.symbols import (
 )
 from fpy.syntax import (
     Ast,
-    AstAnonArray,
-    AstAnonStruct,
     AstAssert,
     AstAssign,
     AstBinaryOp,
@@ -151,15 +149,9 @@ def create_byte_buffer(
 def is_addressable(expr: AstExpr, state: CompileState) -> bool:
     """True when *expr* denotes a location rather than a computed value, so
     that a pointer to it can be formed: *expr* is a variable, or a
-    member/element access. An access into an anonymous literal is the
-    exception -- that literal is never built, so the access reduces to the
-    accessed member's own expression instead."""
+    member/element access."""
     sym = state.resolved_symbols.get(expr)
-    if is_instance_compat(sym, VariableSymbol):
-        return True
-    return is_instance_compat(sym, FieldAccess) and not is_instance_compat(
-        sym.parent_expr, (AstAnonStruct, AstAnonArray)
-    )
+    return is_instance_compat(sym, (VariableSymbol, FieldAccess))
 
 
 class EmitLlvmExpr(Emitter):
@@ -180,7 +172,7 @@ class EmitLlvmExpr(Emitter):
         if value is not None:
             if not value.type.is_concrete:
                 # Only a bare expression statement leaves a constant at an
-                # abstract type (Integer/Float/InternalString/anon literal):
+                # abstract type (Integer/Float/InternalString):
                 # every other position coerces its expression to a concrete
                 # contextual type. An abstract value has no machine
                 # representation, and a constant is pure (const folding only
@@ -464,32 +456,12 @@ class EmitLlvmExpr(Emitter):
         # A qualified name can't denote a variable (an imported sequence may
         # not declare a top-level variable), so what remains is member access.
         assert is_instance_compat(sym, FieldAccess), sym
-        if is_addressable(node, state):
-            return self.builder.load(self._emit_ptr(node, state), name=node.attr)
-        # Member access on an anonymous struct literal: the struct is never
-        # built; emit just the accessed member's expression.
-        assert is_instance_compat(sym.parent_expr, AstAnonStruct), sym.parent_expr
-        for name, value_expr in sym.parent_expr.members:
-            if name == node.attr:
-                return self.emit(value_expr, state)
-        assert False, f"member {node.attr} not found in anon struct"
+        return self.builder.load(self._emit_ptr(node, state), name=node.attr)
 
     def emit_AstIndexExpr(self, node: AstIndexExpr, state: CompileState) -> ir.Value:
         sym = state.resolved_symbols[node]
         assert is_instance_compat(sym, FieldAccess), sym
-        if is_addressable(node, state):
-            return self.builder.load(self._emit_ptr(node, state))
-        # Element access on an anonymous array literal: the array is never
-        # built; the index must be a compile-time constant, so emit just that
-        # element's expression.
-        assert is_instance_compat(sym.parent_expr, AstAnonArray), sym.parent_expr
-        idx_value = state.const_expr_values.get(node.item)
-        assert (
-            idx_value is not None
-        ), "Dynamic indexing on anonymous array literals is not supported"
-        idx = idx_value.val
-        assert 0 <= idx < len(sym.parent_expr.elements), f"Index {idx} out of bounds"
-        return self.emit(sym.parent_expr.elements[idx], state)
+        return self.builder.load(self._emit_ptr(node, state))
 
     def _emit_tlm_prm_read(
         self, node: AstExpr, sym: ChDef | PrmDef, state: CompileState
@@ -936,7 +908,7 @@ class AssignAddresses(TopDownVisitor):
         if state.const_expr_values.get(access) is not None:
             return None  # folded to a constant, so no address is taken
         if not is_addressable(access, state):
-            return None  # a qualified name, or a never-built anonymous literal
+            return None  # a qualified name
 
         # _emit_ptr copies its argument to a slot on exactly this condition.
         parent = state.resolved_symbols[access].parent_expr

--- a/src/fpy/compiler.py
+++ b/src/fpy/compiler.py
@@ -15,6 +15,7 @@ from fpy.codegen_fpybc import (
     ResolveLabels,
 )
 from fpy.desugaring import (
+    DesugarAnonExprs,
     DesugarAugmentedAssignments,
     DesugarDefaultArgs,
     DesugarForLoops,
@@ -273,6 +274,10 @@ def analyze_ast(body: AstBlock, state: CompileState) -> CompileState:
         ResolveSequenceDependencies(),
         # this pass resolves all attributes and items, as well as determines the type of expressions
         PickTypesAndResolveFields(),
+        # now that every anonymous struct/array has been given a type, turn
+        # each into a call of that type's constructor (and reject any that
+        # were not given a type), so no later pass sees an anonymous expr
+        DesugarAnonExprs(),
         # Calculate const values for default arguments first (and check they're const).
         # This must happen before CalculateConstExprValues because call sites may
         # reference functions defined later in the source, and we need the default

--- a/src/fpy/compiler.py
+++ b/src/fpy/compiler.py
@@ -28,6 +28,7 @@ from fpy.semantics import (
     CreateScopes,
     CheckResolvedSymbolKinds,
     CheckAllUnqualifiedIdentifiersResolved,
+    CheckAnonStructMembers,
     CheckAssignSyntax,
     CheckSequenceMetadataDefinedAtTop,
     CalculateConstExprValues,
@@ -237,6 +238,8 @@ def analyze_ast(body: AstBlock, state: CompileState) -> CompileState:
         CreateScopes(),
         # check that assignment targets are valid
         CheckAssignSyntax(),
+        # check that no anonymous struct names a member twice
+        CheckAnonStructMembers(),
         # register all user-defined functions in the global callable scope
         # (and the builtin library functions in the shared base callable scope)
         DefineFunctions(),

--- a/src/fpy/desugaring.py
+++ b/src/fpy/desugaring.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 import copy
-from typing import Union
 from fpy.bytecode.directives import BinaryStackOp, Directive, LoopVarType
 from lark.tree import Meta
 from fpy.syntax import (
     Ast,
-    AstAnonArray,
-    AstAnonStruct,
+    AstAnonExpr,
     AstAssert,
     AstAssign,
     AstAugAssign,
@@ -38,7 +36,6 @@ from fpy.types import (
 from fpy.state import (
     CompileState,
     ForLoopAnalysis,
-    make_type_ctor,
 )
 from fpy.error import WarningType
 from fpy.symbols import (
@@ -905,17 +902,16 @@ class DesugarAnonExprs(Transformer):
 
     def __init__(self):
         super().__init__()
-        # FIXME use type union for anonstruct/array
-        self.replaced: dict[Ast, AstFuncCall] = {}
+        self.replaced: dict[AstAnonExpr, AstFuncCall] = {}
         """each desugared anonymous expr -> the call that replaced it"""
 
     def run(self, start: Ast, state: CompileState):
         super().run(start, state)
         if len(state.errors) != 0:
             return
-        # FIXME confusing comment. make much more clear and use simple language
-        # A call's resolved args are a list of the call's own, so point any
-        # that name a desugared anonymous expr at its replacement.
+        # Replacing a node in the tree does not replace it in
+        # state.resolved_args, which lists argument nodes separately from the
+        # tree. Do that here, for every call.
         for call, args in state.resolved_args.items():
             state.resolved_args[call] = [
                 self.replaced.get(arg, arg) if isinstance(arg, Ast) else arg
@@ -923,27 +919,17 @@ class DesugarAnonExprs(Transformer):
             ]
 
     def visit_AstAnonStruct_AstAnonArray(
-        self, node: Union[AstAnonStruct, AstAnonArray], state: CompileState
+        self, node: AstAnonExpr, state: CompileState
     ) -> AstFuncCall:
-        target = state.contextual_types[node]
-        if target.kind not in (TypeKind.STRUCT, TypeKind.ARRAY):
-            # FIXME is there a more clear and obvious way to check that the
-            # expr was coerced to a type? also let's use a more generic error message, avoid
-            # mentioning anonymous i think
-            if isinstance(node, AstAnonStruct):
-                what, a_kind = "struct", "a struct"
-            else:
-                what, a_kind = "array", "an array"
-            state.err(
-                f"Anonymous {what} is not used where {a_kind} type is expected, "
-                f"so its type cannot be determined",
-                node,
-            )
+        # An expr's contextual type is its own (synthesized) type until
+        # something coerces it. Nothing coerced this one, so it has no type.
+        if state.contextual_types[node] == state.synthesized_types[node]:
+            state.err("Cannot infer the type of this expression from its context", node)
             return None
+        target = state.contextual_types[node]
+        assert target.kind in (TypeKind.STRUCT, TypeKind.ARRAY), target
 
-        # FIXME this is wrong, why are we constructing a new symbol here? we should look up a symbol
-        # or there should be some mapping of type to type ctor
-        ctor = make_type_ctor(target.name, target)
+        ctor = state.type_ctors[target]
         func = AstIdent(node.meta, target.name)
         func.id = state.next_node_id
         state.next_node_id += 1

--- a/src/fpy/desugaring.py
+++ b/src/fpy/desugaring.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 import copy
+from typing import Union
 from fpy.bytecode.directives import BinaryStackOp, Directive, LoopVarType
 from lark.tree import Meta
 from fpy.syntax import (
     Ast,
+    AstAnonArray,
+    AstAnonStruct,
     AstAssert,
     AstAssign,
     AstAugAssign,
@@ -26,6 +29,7 @@ from fpy.types import (
     FpyType,
     FpyValue,
     INTEGER,
+    TypeKind,
     TIME_OPS,
     TIME_COMPARISON,
     BOOL,
@@ -34,6 +38,7 @@ from fpy.types import (
 from fpy.state import (
     CompileState,
     ForLoopAnalysis,
+    make_type_ctor,
 )
 from fpy.error import WarningType
 from fpy.symbols import (
@@ -883,3 +888,77 @@ class DesugarTimeOperators(Transformer):
             return self._make_cmp_expr(node, func_name, state)
         else:
             return self._make_func_call(node, func_name, result_type, state)
+
+
+class DesugarAnonExprs(Transformer):
+    """Desugar each anonymous struct/array into a call of the constructor of
+    the type it was coerced to:
+
+        {seconds: 1, useconds: 0}   becomes   Fw.TimeIntervalValue(1, 0)
+        [1, 2]                      becomes   Svc.ComQueueDepth(1, 2)
+
+    with the call's arguments being the resolved arguments PickTypes recorded
+    for the anonymous expr (in member/element order, defaults filled in). An
+    anonymous expr that was not coerced to a struct or array type has no
+    constructor to become, and is an error.
+    """
+
+    def __init__(self):
+        super().__init__()
+        # FIXME use type union for anonstruct/array
+        self.replaced: dict[Ast, AstFuncCall] = {}
+        """each desugared anonymous expr -> the call that replaced it"""
+
+    def run(self, start: Ast, state: CompileState):
+        super().run(start, state)
+        if len(state.errors) != 0:
+            return
+        # FIXME confusing comment. make much more clear and use simple language
+        # A call's resolved args are a list of the call's own, so point any
+        # that name a desugared anonymous expr at its replacement.
+        for call, args in state.resolved_args.items():
+            state.resolved_args[call] = [
+                self.replaced.get(arg, arg) if isinstance(arg, Ast) else arg
+                for arg in args
+            ]
+
+    def visit_AstAnonStruct_AstAnonArray(
+        self, node: Union[AstAnonStruct, AstAnonArray], state: CompileState
+    ) -> AstFuncCall:
+        target = state.contextual_types[node]
+        if target.kind not in (TypeKind.STRUCT, TypeKind.ARRAY):
+            # FIXME is there a more clear and obvious way to check that the
+            # expr was coerced to a type? also let's use a more generic error message, avoid
+            # mentioning anonymous i think
+            if isinstance(node, AstAnonStruct):
+                what, a_kind = "struct", "a struct"
+            else:
+                what, a_kind = "array", "an array"
+            state.err(
+                f"Anonymous {what} is not used where {a_kind} type is expected, "
+                f"so its type cannot be determined",
+                node,
+            )
+            return None
+
+        # FIXME this is wrong, why are we constructing a new symbol here? we should look up a symbol
+        # or there should be some mapping of type to type ctor
+        ctor = make_type_ctor(target.name, target)
+        func = AstIdent(node.meta, target.name)
+        func.id = state.next_node_id
+        state.next_node_id += 1
+        state.resolved_symbols[func] = ctor
+
+        # the resolved args may contain anonymous exprs that were just desugared
+        args = [
+            self.replaced.get(arg, arg) if isinstance(arg, Ast) else arg
+            for arg in state.resolved_args[node]
+        ]
+        call = AstFuncCall(node.meta, func, args)
+        call.id = state.next_node_id
+        state.next_node_id += 1
+        state.synthesized_types[call] = target
+        state.contextual_types[call] = target
+        state.resolved_args[call] = args
+        self.replaced[node] = call
+        return call

--- a/src/fpy/grammar.lark
+++ b/src/fpy/grammar.lark
@@ -195,7 +195,7 @@ _test: or_test
 anon_struct: "{" [_anon_struct_members] "}"
 _anon_struct_members: anon_struct_member ("," anon_struct_member)* ","?
 anon_struct_member: NAME ":" expr
-# -> AstAnonStruct(members)
+# -> AstAnonStruct(members), each member an AstNamedArgument(name, value)
 
 # anonymous array expression: [] or [expr, expr, ...]
 anon_array: "[" [_anon_array_elements] "]"

--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -1313,7 +1313,7 @@ class PickTypesAndResolveFields(Visitor):
         ctor = state.type_ctors[target]
         if not self._check_ctor_type(ctor, node, state):
             return False
-        if self._resolve_call(node, ctor, args, state) is None:
+        if self.bind_and_coerce_args(node, ctor, args, state) is None:
             return False
         state.contextual_types[node] = target
         return True
@@ -1803,11 +1803,11 @@ class PickTypesAndResolveFields(Visitor):
         resolved = self._resolve_time_op(lhs_type, rhs_type, node.op)
         if resolved is not None:
             resolved_lhs, resolved_rhs, common_type, result_type, _, _ = resolved
-            if not self.coerce_expr_type(node.lhs, resolved_lhs, state):
-                return
-            if not self.coerce_expr_type(node.rhs, resolved_rhs, state):
-                return
-                # FIXME prove that this can happen with a test
+            # _resolve_time_op confirmed each operand can coerce to its time
+            # type, and those types have only scalar members, so coercion
+            # cannot fail here
+            assert self.coerce_expr_type(node.lhs, resolved_lhs, state)
+            assert self.coerce_expr_type(node.rhs, resolved_rhs, state)
             state.op_intermediate_types[node] = common_type
             state.synthesized_types[node] = result_type
             state.contextual_types[node] = result_type
@@ -1884,21 +1884,20 @@ class PickTypesAndResolveFields(Visitor):
         state.synthesized_types[node] = anon_type
         state.contextual_types[node] = anon_type
 
-    def resolve_args(
+    def bind_args(
         self,
-        node: AstFuncCall,
+        node: Ast,
         func: CallableSymbol,
         node_args: list,
         state: CompileState,
     ) -> list[AstExpr] | CompileError:
-        """Resolve a function call's arguments.
+        """Bind a call's arguments to *func*'s parameters: positional
+        arguments in order, named arguments by name, and each parameter's
+        default for an argument not given. Checks each bound argument can be
+        coerced to its parameter's type.
 
-        Reorders named arguments to positional order, fills in default values
-        for missing optional arguments, checks for missing required arguments,
-        and validates argument types are compatible.
-
-        Returns assigned_args on success.
-        Returns a CompileError if there's an issue with the arguments.
+        Returns the bound arguments, one per parameter in parameter order, or
+        a CompileError if an argument cannot be bound.
         """
         func_args = func.args
         param_name_to_idx = {a[0]: i for i, a in enumerate(func_args)}
@@ -2002,47 +2001,40 @@ class PickTypesAndResolveFields(Visitor):
         return assigned
 
     def visit_AstFuncCall(self, node: AstFuncCall, state: CompileState):
-        func = state.resolved_symbols.get(node.func)
-        # FIXME this should be in another pass. maybe could put in an existing one? can you prove this can get hit?
-        if func is None:
-            # if it were a reference to a callable, it would have already been resolved
-            # if it were a symbol to something else, it would have already errored
-            # so it's not even a symbol, just some expr
-            state.err(f"Unknown function", node.func)
-            return
+        # CheckResolvedSymbolKinds rejected any callee that did not resolve to
+        # a callable
+        func = state.resolved_symbols[node.func]
+        assert is_instance_compat(func, CallableSymbol), func
 
         if is_instance_compat(func, TypeCtorSymbol):
             if not self._check_ctor_type(func, node.func, state):
                 return
 
         node_args = node.args if node.args else []
-        if self._resolve_call(node, func, node_args, state) is None:
+        if self.bind_and_coerce_args(node, func, node_args, state) is None:
             return
 
         state.synthesized_types[node] = func.return_type
         state.contextual_types[node] = func.return_type
 
-    # FIXME I think the usage of resolve in both this func and resolve_args is really loose. please
-    # suggest some better names, please use existing, simple language.
-    def _resolve_call(
+    def bind_and_coerce_args(
         self,
         node: Ast,
         func: CallableSymbol,
         node_args: list,
         state: CompileState,
     ) -> list[AstExpr] | None:
-        """Resolve the arguments *node_args* of a call of *func* (see
-        resolve_args), record them in state.resolved_args, and coerce each
-        argument expression to its parameter's type. Returns the resolved
-        arguments, or None after reporting an error."""
-        resolved_args = self.resolve_args(node, func, node_args, state)
-        if is_instance_compat(resolved_args, CompileError):
-            state.errors.append(resolved_args)
+        """Bind a call's arguments to *func*'s parameters (bind_args), record
+        them in state.resolved_args, and coerce each to its parameter's type.
+        Returns the bound arguments, or None after reporting an error."""
+        args = self.bind_args(node, func, node_args, state)
+        if is_instance_compat(args, CompileError):
+            state.errors.append(args)
             return None
-        state.resolved_args[node] = resolved_args
+        state.resolved_args[node] = args
 
         if is_instance_compat(func, CastSymbol):
-            node_arg = resolved_args[0]
+            node_arg = args[0]
             output_type = func.to_type
             # we're going from input_type to output type, and we're going to ignore
             # the coercion rules
@@ -2051,9 +2043,9 @@ class PickTypesAndResolveFields(Visitor):
             # let us turn off some checks for boundaries later when we do const folding
             # we turn off the checks because the user is asking us to force this!
             state.expr_explicit_casts.append(node_arg)
-            return resolved_args
+            return args
 
-        for value_expr, arg in zip(resolved_args, func.args):
+        for value_expr, arg in zip(args, func.args):
             target_type = arg[1]
             # Skip coercion for FpyValue defaults from builtins or type constructors
             if not is_instance_compat(value_expr, Ast):
@@ -2064,7 +2056,7 @@ class PickTypesAndResolveFields(Visitor):
                 continue
             if not self.coerce_expr_type(value_expr, target_type, state):
                 return None
-        return resolved_args
+        return args
 
     def visit_AstRange(self, node: AstRange, state: CompileState):
         if not self.coerce_expr_type(node.lower_bound, LoopVarType, state):

--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -49,6 +49,7 @@ from fpy.types import (
 from fpy.state import (
     CompileState,
     ForLoopAnalysis,
+    make_type_ctor,
 )
 from fpy.error import WarningType
 from fpy.symbols import (
@@ -547,8 +548,8 @@ class AssignNameGroups(Visitor):
             state.contextual_name_group[node.value] = NameGroup.VALUE
 
     def visit_AstAnonStruct(self, node: AstAnonStruct, state: CompileState):
-        for _, value_expr in node.members:
-            state.contextual_name_group[value_expr] = NameGroup.VALUE
+        for member in node.members:
+            state.contextual_name_group[member.value] = NameGroup.VALUE
 
     def visit_AstAnonArray(self, node: AstAnonArray, state: CompileState):
         for elem_expr in node.elements:
@@ -1247,12 +1248,15 @@ class PickTypesAndResolveFields(Visitor):
         unconverted_type = state.synthesized_types[node]
         current_contextual = state.contextual_types[node]
 
-        # Already coerced — idempotent if same target, bug if different
+        # Already coerced. Idempotent if same target, bug if different
         if current_contextual != unconverted_type:
             assert (
                 current_contextual == type
             ), f"double coercion: {unconverted_type} -> {current_contextual} vs {type}"
             return True
+
+        if unconverted_type.kind in (TypeKind.ANON_STRUCT, TypeKind.ANON_ARRAY):
+            return self._coerce_anon_expr(node, unconverted_type, type, state)
 
         if not self.can_coerce_type(unconverted_type, type):
             state.err(
@@ -1271,56 +1275,45 @@ class PickTypesAndResolveFields(Visitor):
             else:
                 type = unconverted_type
 
-        # For anon structs/arrays, recursively coerce children and build resolved_args
-        if unconverted_type.kind == TypeKind.ANON_STRUCT:
-            return self._coerce_anon_struct(node, type, state)
-        if unconverted_type.kind == TypeKind.ANON_ARRAY:
-            return self._coerce_anon_array(node, type, state)
-
         state.contextual_types[node] = type
         return True
 
-    def _coerce_anon_struct(
-        self, node: AstAnonStruct, target: FpyType, state: CompileState
+    def _coerce_anon_expr(
+        self,
+        node: Union[AstAnonStruct, AstAnonArray],
+        anon_type: FpyType,
+        target: FpyType,
+        state: CompileState,
     ) -> bool:
-        """Recursively coerce each provided member and build resolved_args.
+        """Coerce an anonymous struct/array to *target*. The anonymous expr is
+        a call of the target type's constructor, with its members as named
+        arguments / its elements as positional arguments, so its members/elements are resolved and coerced as
+        that call's arguments, and a mismatch is reported as it would be for
+        the call."""
+        if anon_type.kind == TypeKind.ANON_STRUCT:
+            target_kind, args = TypeKind.STRUCT, node.members
+        else:
+            target_kind, args = TypeKind.ARRAY, node.elements
+        # FIXME it's not obvious to me why the check for is_type_constant_size is here
+        # Also, why do we need this check, shouldn't resolve args handle it for us?
+        if target.kind != target_kind or not is_type_constant_size(target):
+            state.err(
+                f"Expected {target.display_name}, found {anon_type.display_name}",
+                node,
+            )
+            return False
 
-        Called after can_coerce_type has already confirmed structural compatibility.
-        """
-        provided_members = {name: value_expr for name, value_expr in node.members}
-
-        # Build resolved list in target member order: coerce provided, fill defaults
-        resolved_members = []
-        for member in target.members:
-            if member.name in provided_members:
-                value_expr = provided_members[member.name]
-                if not self.coerce_expr_type(value_expr, member.type, state):
-                    return False
-                resolved_members.append(value_expr)
-            else:
-                resolved_members.append(target.member_defaults[member.name])
-
-        state.resolved_args[node] = resolved_members
-        state.contextual_types[node] = target
-        return True
-
-    def _coerce_anon_array(
-        self, node: AstAnonArray, target: FpyType, state: CompileState
-    ) -> bool:
-        """Recursively coerce each provided element and build resolved_args.
-
-        Called after can_coerce_type has already confirmed structural compatibility.
-        """
-        # Coerce each provided element to the target element type
-        for elem_expr in node.elements:
-            if not self.coerce_expr_type(elem_expr, target.elem_type, state):
+        # FIXME stop creating symbols, this is wrong
+        ctor = make_type_ctor(target.name, target)
+        resolved = self.resolve_args(node, ctor, args, state)
+        if is_instance_compat(resolved, CompileError):
+            state.errors.append(resolved)
+            return False
+        for value_expr, (_, arg_type, _) in zip(resolved, ctor.args):
+            if not is_instance_compat(value_expr, Ast):
+                continue  # a filled-in FpyValue default
+            if not self.coerce_expr_type(value_expr, arg_type, state):
                 return False
-
-        # Build resolved list: provided elements + defaults for missing positions.
-        resolved = list(node.elements)
-        for i in range(len(node.elements), target.length):
-            resolved.append(target.elem_defaults[i])
-
         state.resolved_args[node] = resolved
         state.contextual_types[node] = target
         return True
@@ -1450,11 +1443,8 @@ class PickTypesAndResolveFields(Visitor):
             return None
 
         target_members = {m.name: m for m in concrete.members}
-        seen: set[str] = set()
+        # FIXME explain this change
         for member in anon.members:
-            if member.name in seen:
-                return None
-            seen.add(member.name)
             if member.name not in target_members:
                 return None
             if not self.can_coerce_type(member.type, target_members[member.name].type):
@@ -1517,25 +1507,11 @@ class PickTypesAndResolveFields(Visitor):
             parent_type = state.synthesized_types[node.parent]
 
             if parent_type.kind == TypeKind.ANON_STRUCT:
-                # Direct member access on anonymous struct literal
-                member_type = None
-                for m in parent_type.members:
-                    if m.name == node.attr:
-                        member_type = m.type
-                        break
-                if member_type is None:
-                    state.err(
-                        f"Anonymous struct has no member named '{node.attr}'",
-                        node,
-                    )
-                    return
-                this_sym = FieldAccess(
-                    is_struct_member=True,
-                    parent_expr=node.parent,
-                    type=member_type,
-                    base_sym=None,
-                    name=node.attr,
+                state.err(
+                    "Cannot access a member of an anonymous struct",
+                    node,
                 )
+                return
             elif parent_type.kind == TypeKind.STRUCT:
                 if not is_type_constant_size(parent_type):
                     state.err(
@@ -1610,26 +1586,10 @@ class PickTypesAndResolveFields(Visitor):
         parent_type = state.synthesized_types[node.parent]
 
         if parent_type.kind == TypeKind.ANON_ARRAY:
-            # Index access on anonymous array literal
-            if parent_type.length == 0:
-                state.err("Cannot index into an empty anonymous array", node)
-                return
-
-            # coerce the index expression to array index type
-            if not self.coerce_expr_type(node.item, ArrayIndexType, state):
-                return
-
-            sym = FieldAccess(
-                is_array_element=True,
-                parent_expr=node.parent,
-                type=parent_type.elem_type,
-                base_sym=None,
-                idx_expr=node.item,
+            state.err(
+                "Cannot index an anonymous array",
+                node,
             )
-
-            state.resolved_symbols[node] = sym
-            state.synthesized_types[node] = parent_type.elem_type
-            state.contextual_types[node] = parent_type.elem_type
             return
 
         if parent_type.kind != TypeKind.ARRAY:
@@ -1885,18 +1845,19 @@ class PickTypesAndResolveFields(Visitor):
         state.contextual_types[node] = BOOL
 
     def visit_AstAnonStruct(self, node: AstAnonStruct, state: CompileState):
-        # Check for duplicate member names
         seen_names: set[str] = set()
-        for name, _ in node.members:
-            if name in seen_names:
-                state.err(f"Duplicate member '{name}' in anonymous struct", node)
+        # FIXME duplicate member check and other similar anon expr checks could be put into separate pass
+        for member in node.members:
+            if member.name in seen_names:
+                state.err(
+                    f"Duplicate member '{member.name}' in anonymous struct", member
+                )
                 return
-            seen_names.add(name)
+            seen_names.add(member.name)
 
         # Synthesize an anonymous struct type from the member expressions
         members = tuple(
-            StructMember(name, state.synthesized_types[value_expr])
-            for name, value_expr in node.members
+            StructMember(m.name, state.synthesized_types[m.value]) for m in node.members
         )
         anon_type = FpyType(
             TypeKind.ANON_STRUCT,
@@ -1907,22 +1868,11 @@ class PickTypesAndResolveFields(Visitor):
         state.contextual_types[node] = anon_type
 
     def visit_AstAnonArray(self, node: AstAnonArray, state: CompileState):
-        # Synthesize an anonymous array type from the element expressions
-        elem_types = [state.synthesized_types[elem] for elem in node.elements]
-        # Compute common element type
-        common_elem_type = None
-        if len(elem_types) > 0:
-            common_elem_type = elem_types[0]
-            for et in elem_types[1:]:
-                common_elem_type = self.find_common_type(common_elem_type, et)
-                if common_elem_type is None:
-                    state.err("Array elements have no common type", node)
-                    return
+        # Synthesize an anonymous array type.
         anon_type = FpyType(
             TypeKind.ANON_ARRAY,
-            f"$AnonArray[{len(elem_types)}]",
+            f"$AnonArray[{len(node.elements)}]",
             length=len(node.elements),
-            elem_type=common_elem_type,
         )
         state.synthesized_types[node] = anon_type
         state.contextual_types[node] = anon_type
@@ -2457,28 +2407,15 @@ class CalculateConstExprValues(Visitor):
         elif is_instance_compat(sym, FieldAccess):
             parent_value = state.const_expr_values[node.parent]
             if parent_value is None:
-                # Parent is not const. For anon struct, try getting the member
-                # expression's const value directly.
-                if is_instance_compat(node.parent, AstAnonStruct):
-                    for name, value_expr in node.parent.members:
-                        if name == node.attr:
-                            member_val = state.const_expr_values.get(value_expr)
-                            if member_val is not None:
-                                expr_value = member_val
-                            break
-                if expr_value is None:
-                    state.const_expr_values[node] = None
-                    return
-            else:
-                # we are accessing an attribute of something with an fprime value at compile time
-                # we must be getting a member
-                if isinstance(parent_value, FpyValue) and parent_value.type.kind in (
-                    TypeKind.STRUCT,
-                    TypeKind.ANON_STRUCT,
-                ):
-                    expr_value = parent_value.val[node.attr]
-                else:
-                    assert False, parent_value
+                state.const_expr_values[node] = None
+                return
+            # we are accessing an attribute of something with an fprime value at compile time
+            # we must be getting a member
+            assert (
+                isinstance(parent_value, FpyValue)
+                and parent_value.type.kind == TypeKind.STRUCT
+            ), parent_value
+            expr_value = parent_value.val[node.attr]
 
         assert expr_value is not None
 
@@ -2509,9 +2446,9 @@ class CalculateConstExprValues(Visitor):
             state.const_expr_values[node] = None
             return
 
-        assert isinstance(parent_value, FpyValue) and parent_value.type.kind in (
-            TypeKind.ARRAY,
-            TypeKind.ANON_ARRAY,
+        assert (
+            isinstance(parent_value, FpyValue)
+            and parent_value.type.kind == TypeKind.ARRAY
         ), parent_value
 
         idx = state.const_expr_values.get(node.item)
@@ -2867,54 +2804,6 @@ class CalculateConstExprValues(Visitor):
         # ranges don't really end up having a value, they kinda just exist as a type
         state.const_expr_values[node] = None
 
-    def visit_AstAnonStruct(self, node: AstAnonStruct, state: CompileState):
-        converted_type = state.contextual_types[node]
-
-        if converted_type.kind == TypeKind.ANON_STRUCT:
-            exprs = [value_expr for _, value_expr in node.members]
-            names = [name for name, _ in node.members]
-        else:
-            assert converted_type.kind == TypeKind.STRUCT, converted_type
-            exprs = state.resolved_args[node]
-            names = [m.name for m in converted_type.members]
-
-        values = []
-        for expr in exprs:
-            if is_instance_compat(expr, Ast):
-                val = state.const_expr_values.get(expr)
-                if val is None:
-                    state.const_expr_values[node] = None
-                    return
-                values.append(val)
-            else:
-                values.append(expr)
-
-        state.const_expr_values[node] = FpyValue(
-            converted_type, dict(zip(names, values))
-        )
-
-    def visit_AstAnonArray(self, node: AstAnonArray, state: CompileState):
-        converted_type = state.contextual_types[node]
-
-        if converted_type.kind == TypeKind.ANON_ARRAY:
-            exprs = list(node.elements)
-        else:
-            assert converted_type.kind == TypeKind.ARRAY, converted_type
-            exprs = state.resolved_args[node]
-
-        values = []
-        for expr in exprs:
-            if is_instance_compat(expr, Ast):
-                val = state.const_expr_values.get(expr)
-                if val is None:
-                    state.const_expr_values[node] = None
-                    return
-                values.append(val)
-            else:
-                values.append(expr)
-
-        state.const_expr_values[node] = FpyValue(converted_type, values)
-
     def visit_default(self, node, state):
         # coding error, missed an expr
         assert not is_instance_compat(node, AstExpr), node
@@ -2997,15 +2886,10 @@ class CheckConstArrayAccesses(Visitor):
         idx_value = state.const_expr_values.get(node.item)
 
         parent_type = state.contextual_types[node.parent]
-        assert parent_type.kind in (TypeKind.ARRAY, TypeKind.ANON_ARRAY), parent_type
+        assert parent_type.kind == TypeKind.ARRAY, parent_type
 
         if idx_value is None:
             # can't check at compile time
-            if parent_type.kind == TypeKind.ANON_ARRAY:
-                state.err(
-                    "Index on anonymous array must be a compile-time constant",
-                    node.item,
-                )
             return
 
         if idx_value.val < 0 or idx_value.val >= parent_type.length:

--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -49,7 +49,6 @@ from fpy.types import (
 from fpy.state import (
     CompileState,
     ForLoopAnalysis,
-    make_type_ctor,
 )
 from fpy.error import WarningType
 from fpy.symbols import (
@@ -94,6 +93,7 @@ from fpy.bytecode.directives import (
 )
 from fpy.syntax import (
     AstAssert,
+    AstAnonExpr,
     AstAnonStruct,
     AstAnonArray,
     AstBinaryOp,
@@ -270,6 +270,16 @@ class CheckAssignSyntax(TopDownVisitor):
                 node,
             )
             return
+
+
+class CheckAnonStructMembers(Visitor):
+    def visit_AstAnonStruct(self, node: AstAnonStruct, state: CompileState):
+        seen_names: set[str] = set()
+        for member in node.members:
+            if member.name in seen_names:
+                state.err(f"Duplicate member '{member.name}'", member)
+                return
+            seen_names.add(member.name)
 
 
 class DefineFunctions(TopDownVisitor):
@@ -1280,43 +1290,47 @@ class PickTypesAndResolveFields(Visitor):
 
     def _coerce_anon_expr(
         self,
-        node: Union[AstAnonStruct, AstAnonArray],
+        node: AstAnonExpr,
         anon_type: FpyType,
         target: FpyType,
         state: CompileState,
     ) -> bool:
         """Coerce an anonymous struct/array to *target*. The anonymous expr is
         a call of the target type's constructor, with its members as named
-        arguments / its elements as positional arguments, so its members/elements are resolved and coerced as
-        that call's arguments, and a mismatch is reported as it would be for
-        the call."""
+        arguments / its elements as positional arguments, so it is checked
+        exactly as that call would be."""
         if anon_type.kind == TypeKind.ANON_STRUCT:
             target_kind, args = TypeKind.STRUCT, node.members
         else:
             target_kind, args = TypeKind.ARRAY, node.elements
-        # FIXME it's not obvious to me why the check for is_type_constant_size is here
-        # Also, why do we need this check, shouldn't resolve args handle it for us?
-        if target.kind != target_kind or not is_type_constant_size(target):
+        if target.kind != target_kind:
             state.err(
                 f"Expected {target.display_name}, found {anon_type.display_name}",
                 node,
             )
             return False
 
-        # FIXME stop creating symbols, this is wrong
-        ctor = make_type_ctor(target.name, target)
-        resolved = self.resolve_args(node, ctor, args, state)
-        if is_instance_compat(resolved, CompileError):
-            state.errors.append(resolved)
+        ctor = state.type_ctors[target]
+        if not self._check_ctor_type(ctor, node, state):
             return False
-        for value_expr, (_, arg_type, _) in zip(resolved, ctor.args):
-            if not is_instance_compat(value_expr, Ast):
-                continue  # a filled-in FpyValue default
-            if not self.coerce_expr_type(value_expr, arg_type, state):
-                return False
-        state.resolved_args[node] = resolved
+        if self._resolve_call(node, ctor, args, state) is None:
+            return False
         state.contextual_types[node] = target
         return True
+
+    def _check_ctor_type(
+        self, ctor: TypeCtorSymbol, node: Ast, state: CompileState
+    ) -> bool:
+        """A constructor call makes a runtime value of its type, and a runtime
+        value must be constant-sized. Reports an error at *node* and returns
+        False if the type is not."""
+        if is_type_constant_size(ctor.type):
+            return True
+        state.err(
+            f"Type {ctor.type.display_name} is not constant-sized (contains strings)",
+            node,
+        )
+        return False
 
     def find_common_type(
         self, first_type: FpyType, second_type: FpyType
@@ -1442,8 +1456,9 @@ class PickTypesAndResolveFields(Visitor):
         if not is_type_constant_size(concrete):
             return None
 
+        # every member must exist in the concrete struct and be coercible to
+        # it.
         target_members = {m.name: m for m in concrete.members}
-        # FIXME explain this change
         for member in anon.members:
             if member.name not in target_members:
                 return None
@@ -1508,7 +1523,7 @@ class PickTypesAndResolveFields(Visitor):
 
             if parent_type.kind == TypeKind.ANON_STRUCT:
                 state.err(
-                    "Cannot access a member of an anonymous struct",
+                    "Cannot access a member of a struct literal",
                     node,
                 )
                 return
@@ -1587,7 +1602,7 @@ class PickTypesAndResolveFields(Visitor):
 
         if parent_type.kind == TypeKind.ANON_ARRAY:
             state.err(
-                "Cannot index an anonymous array",
+                "Cannot index an array literal",
                 node,
             )
             return
@@ -1788,9 +1803,11 @@ class PickTypesAndResolveFields(Visitor):
         resolved = self._resolve_time_op(lhs_type, rhs_type, node.op)
         if resolved is not None:
             resolved_lhs, resolved_rhs, common_type, result_type, _, _ = resolved
-            # _resolve_time_op already confirmed coercibility
-            assert self.coerce_expr_type(node.lhs, resolved_lhs, state)
-            assert self.coerce_expr_type(node.rhs, resolved_rhs, state)
+            if not self.coerce_expr_type(node.lhs, resolved_lhs, state):
+                return
+            if not self.coerce_expr_type(node.rhs, resolved_rhs, state):
+                return
+                # FIXME prove that this can happen with a test
             state.op_intermediate_types[node] = common_type
             state.synthesized_types[node] = result_type
             state.contextual_types[node] = result_type
@@ -1845,16 +1862,6 @@ class PickTypesAndResolveFields(Visitor):
         state.contextual_types[node] = BOOL
 
     def visit_AstAnonStruct(self, node: AstAnonStruct, state: CompileState):
-        seen_names: set[str] = set()
-        # FIXME duplicate member check and other similar anon expr checks could be put into separate pass
-        for member in node.members:
-            if member.name in seen_names:
-                state.err(
-                    f"Duplicate member '{member.name}' in anonymous struct", member
-                )
-                return
-            seen_names.add(member.name)
-
         # Synthesize an anonymous struct type from the member expressions
         members = tuple(
             StructMember(m.name, state.synthesized_types[m.value]) for m in node.members
@@ -1996,6 +2003,7 @@ class PickTypesAndResolveFields(Visitor):
 
     def visit_AstFuncCall(self, node: AstFuncCall, state: CompileState):
         func = state.resolved_symbols.get(node.func)
+        # FIXME this should be in another pass. maybe could put in an existing one? can you prove this can get hit?
         if func is None:
             # if it were a reference to a callable, it would have already been resolved
             # if it were a symbol to something else, it would have already errored
@@ -2003,27 +2011,36 @@ class PickTypesAndResolveFields(Visitor):
             state.err(f"Unknown function", node.func)
             return
 
-        # Check that type constructors are for constant-sized types
         if is_instance_compat(func, TypeCtorSymbol):
-            if not is_type_constant_size(func.type):
-                state.err(
-                    f"Type {func.type.display_name} is not constant-sized (contains strings)",
-                    node.func,
-                )
+            if not self._check_ctor_type(func, node.func, state):
                 return
 
         node_args = node.args if node.args else []
-
-        # Resolve args: reorder named args, fill in defaults, check types
-        result = self.resolve_args(node, func, node_args, state)
-        if is_instance_compat(result, CompileError):
-            state.errors.append(result)
+        if self._resolve_call(node, func, node_args, state) is None:
             return
 
-        resolved_args = result
+        state.synthesized_types[node] = func.return_type
+        state.contextual_types[node] = func.return_type
+
+    # FIXME I think the usage of resolve in both this func and resolve_args is really loose. please
+    # suggest some better names, please use existing, simple language.
+    def _resolve_call(
+        self,
+        node: Ast,
+        func: CallableSymbol,
+        node_args: list,
+        state: CompileState,
+    ) -> list[AstExpr] | None:
+        """Resolve the arguments *node_args* of a call of *func* (see
+        resolve_args), record them in state.resolved_args, and coerce each
+        argument expression to its parameter's type. Returns the resolved
+        arguments, or None after reporting an error."""
+        resolved_args = self.resolve_args(node, func, node_args, state)
+        if is_instance_compat(resolved_args, CompileError):
+            state.errors.append(resolved_args)
+            return None
         state.resolved_args[node] = resolved_args
 
-        # go handle coercion/casting
         if is_instance_compat(func, CastSymbol):
             node_arg = resolved_args[0]
             output_type = func.to_type
@@ -2034,20 +2051,20 @@ class PickTypesAndResolveFields(Visitor):
             # let us turn off some checks for boundaries later when we do const folding
             # we turn off the checks because the user is asking us to force this!
             state.expr_explicit_casts.append(node_arg)
-        else:
-            for value_expr, arg in zip(resolved_args, func.args):
-                target_type = arg[1]
-                # Skip coercion for FpyValue defaults from builtins or type constructors
-                if not is_instance_compat(value_expr, Ast):
-                    continue
-                # Skip coercion for default values from forward-called functions.
-                # These will be coerced when the function definition is visited.
-                if value_expr not in state.synthesized_types:
-                    continue
-                assert self.coerce_expr_type(value_expr, target_type, state)
+            return resolved_args
 
-        state.synthesized_types[node] = func.return_type
-        state.contextual_types[node] = func.return_type
+        for value_expr, arg in zip(resolved_args, func.args):
+            target_type = arg[1]
+            # Skip coercion for FpyValue defaults from builtins or type constructors
+            if not is_instance_compat(value_expr, Ast):
+                continue
+            # Skip coercion for default values from forward-called functions.
+            # These will be coerced when the function definition is visited.
+            if value_expr not in state.synthesized_types:
+                continue
+            if not self.coerce_expr_type(value_expr, target_type, state):
+                return None
+        return resolved_args
 
     def visit_AstRange(self, node: AstRange, state: CompileState):
         if not self.coerce_expr_type(node.lower_bound, LoopVarType, state):

--- a/src/fpy/state.py
+++ b/src/fpy/state.py
@@ -156,6 +156,9 @@ class CompileState:
     """expr to the fprime value it will end up being on the stack after type conversions.
     None if unsure at compile time.  NOTHING_VALUE for void expressions."""
 
+    type_ctors: dict[FpyType, TypeCtorSymbol] = field(default_factory=dict)
+    """each struct and array type -> its type constructor"""
+
     resolved_args: dict[Ast, list[AstExpr]] = field(default_factory=dict)
     """Maps function calls (and, until DesugarAnonExprs turns them into type
     constructor calls, anonymous structs and arrays) to resolved arguments in
@@ -515,7 +518,7 @@ def _populate_type_defaults(typ: FpyType) -> None:
         typ.elem_defaults = tuple(array_defaults)
 
 
-def make_type_ctor(name: str, typ: FpyType) -> TypeCtorSymbol | None:
+def _make_type_ctor(name: str, typ: FpyType) -> TypeCtorSymbol | None:
     """Create a TypeCtorSymbol for a type, or return None if it has no callable ctor."""
     if typ.kind == TypeKind.STRUCT:
         args = [(m.name, m.type, typ.member_defaults[m.name]) for m in typ.members]
@@ -532,8 +535,9 @@ def make_type_ctor(name: str, typ: FpyType) -> TypeCtorSymbol | None:
 @lru_cache(maxsize=4)
 def _build_global_scopes(dictionary: str) -> tuple:
     """
-    Build and cache the 3 global scopes and type_name_dict for a dictionary.
-    Returns tuple of (type_scope, callable_scope, values_scope, type_name_dict).
+    Build and cache the 3 global scopes, type_name_dict and type_ctors for a
+    dictionary. Returns tuple of (type_scope, callable_scope, values_scope,
+    type_name_dict, type_ctors).
     """
     d = load_dictionary(dictionary)
     cmd_name_dict = d["cmd_name_dict"]
@@ -625,10 +629,12 @@ def _build_global_scopes(dictionary: str) -> tuple:
             typ.name, typ, [("value", I64, None)], typ
         )
 
+    type_ctors: dict[FpyType, TypeCtorSymbol] = {}
     for name, typ in type_name_dict.items():
-        ctor = make_type_ctor(name, typ)
+        ctor = _make_type_ctor(name, typ)
         if ctor is not None:
             callable_name_dict[name] = ctor
+            type_ctors[typ] = ctor
 
     for macro_name, macro in MACROS.items():
         callable_name_dict[macro_name] = macro
@@ -651,7 +657,7 @@ def _build_global_scopes(dictionary: str) -> tuple:
         ),
     )
 
-    return (type_scope, callable_scope, values_scope, type_name_dict)
+    return (type_scope, callable_scope, values_scope, type_name_dict, type_ctors)
 
 
 def get_base_compile_state(
@@ -664,8 +670,8 @@ def get_base_compile_state(
     main_file_path: str | None = None,
 ) -> CompileState:
     """return the initial state of the compiler, based on the given dict path"""
-    type_scope, callable_scope, values_scope, type_defs = _build_global_scopes(
-        dictionary
+    type_scope, callable_scope, values_scope, type_defs, type_ctors = (
+        _build_global_scopes(dictionary)
     )
     constants = load_dictionary(dictionary)["constants"]
 
@@ -705,6 +711,7 @@ def get_base_compile_state(
 
     state = CompileState(
         type_defs=type_defs,
+        type_ctors=type_ctors,
         ground_binary_dir=ground_binary_dir,
         max_directives_count=_const_int(
             "Svc.Fpy.MAX_SEQUENCE_STATEMENT_COUNT", DEFAULT_MAX_DIRECTIVES_COUNT

--- a/src/fpy/state.py
+++ b/src/fpy/state.py
@@ -157,9 +157,10 @@ class CompileState:
     None if unsure at compile time.  NOTHING_VALUE for void expressions."""
 
     resolved_args: dict[Ast, list[AstExpr]] = field(default_factory=dict)
-    """Maps function calls, anon structs, and anon arrays to resolved arguments
-    in positional order. Default values are filled in for arguments not provided
-    at the call site (or struct members / array elements with defaults)."""
+    """Maps function calls (and, until DesugarAnonExprs turns them into type
+    constructor calls, anonymous structs and arrays) to resolved arguments in
+    positional order. Default values are filled in for arguments not provided
+    at the call site."""
 
     function_global_uses: dict[AstDef, list[VariableSymbol]] = field(
         default_factory=dict
@@ -514,7 +515,7 @@ def _populate_type_defaults(typ: FpyType) -> None:
         typ.elem_defaults = tuple(array_defaults)
 
 
-def _make_type_ctor(name: str, typ: FpyType) -> TypeCtorSymbol | None:
+def make_type_ctor(name: str, typ: FpyType) -> TypeCtorSymbol | None:
     """Create a TypeCtorSymbol for a type, or return None if it has no callable ctor."""
     if typ.kind == TypeKind.STRUCT:
         args = [(m.name, m.type, typ.member_defaults[m.name]) for m in typ.members]
@@ -625,7 +626,7 @@ def _build_global_scopes(dictionary: str) -> tuple:
         )
 
     for name, typ in type_name_dict.items():
-        ctor = _make_type_ctor(name, typ)
+        ctor = make_type_ctor(name, typ)
         if ctor is not None:
             callable_name_dict[name] = ctor
 

--- a/src/fpy/syntax.py
+++ b/src/fpy/syntax.py
@@ -242,6 +242,7 @@ class AstAnonArray(Ast):
 
 
 AstOp = Union[AstBinaryOp, AstUnaryOp]
+AstAnonExpr = Union[AstAnonStruct, AstAnonArray]
 
 AstReference = Union[AstGetAttr, AstIndexExpr, AstIdent]
 AstExpr = Union[

--- a/src/fpy/syntax.py
+++ b/src/fpy/syntax.py
@@ -233,7 +233,7 @@ class AstRange(Ast):
 
 @dataclass
 class AstAnonStruct(Ast):
-    members: list[tuple[str, "AstExpr"]]
+    members: list[AstNamedArgument]
 
 
 @dataclass
@@ -718,7 +718,7 @@ class FpyTransformer(Transformer):
     range = AstRange
 
     anon_struct = no_inline(AstAnonStruct)
-    anon_struct_member = no_inline_or_meta(tuple)
+    anon_struct_member = AstNamedArgument
     anon_array = no_inline(AstAnonArray)
 
     def_stmt = AstDef

--- a/src/fpy/types.py
+++ b/src/fpy/types.py
@@ -311,9 +311,9 @@ class FpyType:
         if self.kind == TypeKind.INTERNAL_STRING:
             return "String"
         if self.kind == TypeKind.ANON_STRUCT:
-            return "anonymous struct"
+            return "struct literal"
         if self.kind == TypeKind.ANON_ARRAY:
-            return "anonymous array"
+            return "array literal"
         if self.kind == TypeKind.SIZED:
             return "a serializable, statically-sized value"
         return self.name

--- a/src/fpy/visitors.py
+++ b/src/fpy/visitors.py
@@ -155,6 +155,22 @@ class Transformer(Visitor):
 
     def run(self, start: Ast, state: CompileState):
 
+        def _transform_elem(elem):
+            """Transform one non-list child, returning its replacement (or
+            itself). A node may not be split into several here."""
+            if not isinstance(elem, Ast):
+                return elem
+            _descend(elem)
+            if len(state.errors) != 0:
+                return elem
+            transformed = self._visit(elem, state)
+            if isinstance(transformed, Ast):
+                return transformed
+            if transformed is Transformer.Delete:
+                return None
+            assert transformed is None, transformed
+            return elem
+
         def _descend(node):
             if not isinstance(node, Ast):
                 return
@@ -169,6 +185,15 @@ class Transformer(Visitor):
                     idx = -1
                     for child in field_val[:]:
                         idx += 1
+                        if isinstance(child, tuple):
+                            # a list of tuples (e.g. function parameters):
+                            # transform each Ast element of the tuple in place
+                            field_val[idx] = tuple(
+                                _transform_elem(elem) for elem in child
+                            )
+                            if len(state.errors) != 0:
+                                break
+                            continue
                         if not isinstance(child, Ast):
                             continue
                         _descend(child)
@@ -207,21 +232,9 @@ class Transformer(Visitor):
                     # don't need to update the field, it was a ptr to a list so should
                     # already be updated
                 else:
-                    _descend(field_val)
+                    setattr(node, field.name, _transform_elem(field_val))
                     if len(state.errors) != 0:
                         break
-                    transformed = self._visit(field_val, state)
-                    if len(state.errors) != 0:
-                        break
-                    if isinstance(transformed, Ast):
-                        setattr(node, field.name, transformed)
-                    elif transformed is Transformer.Delete:
-                        # just delete it
-                        setattr(node, field.name, None)
-                    else:
-                        # cannot return a list if the original attr wasn't a list
-                        assert transformed is None, transformed
-                        # don't do anything, didn't return anything
 
         _descend(start)
         self._visit(start, state)

--- a/test/fpy/test_anon_exprs.py
+++ b/test/fpy/test_anon_exprs.py
@@ -61,14 +61,14 @@ class TestAnonStructErrors:
         seq = """
 val: Fw.TimeIntervalValue = {seconds: 1, nonexistent: 2}
 """
-        assert_compile_failure(fprime_test_api, seq)
+        assert_compile_failure(fprime_test_api, seq, match="Unknown argument")
 
     def test_anon_struct_duplicate_member(self, fprime_test_api):
         """Duplicate member names should fail."""
         seq = """
 val: Fw.TimeIntervalValue = {seconds: 1, seconds: 2}
 """
-        assert_compile_failure(fprime_test_api, seq)
+        assert_compile_failure(fprime_test_api, seq, match="Duplicate member")
 
     def test_anon_struct_wrong_member_type(self, fprime_test_api):
         """Member value type incompatible with target member type."""
@@ -82,7 +82,22 @@ val: Fw.TimeIntervalValue = {seconds: True}
         seq = """
 val: U32 = {seconds: 1}
 """
-        assert_compile_failure(fprime_test_api, seq)
+        assert_compile_failure(fprime_test_api, seq, match="found anonymous struct")
+
+    def test_anon_struct_bare_statement(self, fprime_test_api):
+        """An anonymous struct not coerced to any type has no constructor to
+        become, so it is an error."""
+        seq = """
+{seconds: 1}
+"""
+        assert_compile_failure(fprime_test_api, seq, match="Anonymous struct")
+
+    def test_anon_struct_sized_arg(self, fprime_test_api):
+        """A parameter accepting any sized value gives an anon struct no type."""
+        seq = """
+write_to_port(Svc.Fpy.SerialPortIndex.EXAMPLE_PORT_0, {seconds: 1})
+"""
+        assert_compile_failure(fprime_test_api, seq, match="found anonymous struct")
 
 
 class TestAnonStructAdvanced:
@@ -104,6 +119,37 @@ def make_interval() -> Fw.TimeIntervalValue:
 
 val: Fw.TimeIntervalValue = make_interval()
 assert val.seconds == 42
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_anon_struct_as_named_func_arg(self, fprime_test_api):
+        """Anonymous struct passed as a named function argument."""
+        seq = """
+def check_time(a: U8, t: Fw.TimeIntervalValue) -> bool:
+    return t.seconds == 5 and a == 1
+
+assert check_time(t={seconds: 5}, a=1)
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_anon_struct_as_default_arg(self, fprime_test_api):
+        """Anonymous struct as a parameter's default value."""
+        seq = """
+def secs(t: Fw.TimeIntervalValue = {seconds: 7}) -> U32:
+    return t.seconds
+
+assert secs() == 7
+assert secs({seconds: 8}) == 8
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_anon_struct_as_ctor_arg(self, fprime_test_api):
+        """Anonymous struct passed to a type constructor."""
+        seq = """
+val: Ref.SignalInfo = Ref.SignalInfo(Ref.SignalType.TRIANGLE, [1.0, 2.0], [{time: 3.0, value: 4.0}])
+assert val.history[1] == 2.0
+assert val.pairHistory[0].value == 4.0
+assert val.pairHistory[1].value == 0.0
 """
         assert_run_success(fprime_test_api, seq)
 
@@ -157,7 +203,7 @@ class TestAnonArrayErrors:
         seq = """
 val: Svc.ComQueueDepth = [1, 2, 3]
 """
-        assert_compile_failure(fprime_test_api, seq)
+        assert_compile_failure(fprime_test_api, seq, match="Too many arguments")
 
     def test_anon_array_wrong_element_type(self, fprime_test_api):
         """Element type incompatible with target should fail."""
@@ -171,14 +217,23 @@ val: Svc.ComQueueDepth = [True, False]
         seq = """
 val: U32 = [1, 2, 3]
 """
-        assert_compile_failure(fprime_test_api, seq)
+        # FIXME yeah let's remove the word anonymous from the err msgs
+        assert_compile_failure(fprime_test_api, seq, match="found anonymous array")
+
+    def test_anon_array_bare_statement(self, fprime_test_api):
+        """An anonymous array not coerced to any type has no constructor to
+        become, so it is an error."""
+        seq = """
+[1, 2]
+"""
+        assert_compile_failure(fprime_test_api, seq, match="Anonymous array")
 
     def test_anon_array_incompatible_element_types(self, fprime_test_api):
-        """Anonymous array with incompatible element types should fail."""
+        """Each element is coerced to the target's element type."""
         seq = """
-[1, "hello"]
+val: Svc.ComQueueDepth = [1, "hello"]
 """
-        assert_compile_failure(fprime_test_api, seq, match="common type")
+        assert_compile_failure(fprime_test_api, seq, match="Expected U32, found String")
 
     def test_index_non_array_reports_not_an_array(self, fprime_test_api):
         """Indexing a non-array must report 'not an array', not 'contains strings'."""
@@ -243,52 +298,32 @@ assert val.history[3] == 4.0
 
 
 class TestAnonDirectAccess:
+    """An anonymous literal only gets a type from the context it is coerced
+    in, so there is no type to access a member or element of."""
+
+    # FIXME just keep the old tests around, just have them fail, explain it's to check if in the future
+    # we ever go back to old anon semantics
+
     def test_anon_struct_member_access(self, fprime_test_api):
-        """Access a specific member from an anonymous struct literal."""
         seq = """
 a: U32 = {x: 10, y: 20, z: 30}.y
-assert a == 20
 """
-        assert_run_success(fprime_test_api, seq)
-
-    def test_anon_struct_member_access_nonexistent(self, fprime_test_api):
-        """Accessing a non-existent member should fail."""
-        seq = """
-x: U32 = {xyz: 123}.abc
-"""
-        assert_compile_failure(fprime_test_api, seq)
+        assert_compile_failure(fprime_test_api, seq, match="anonymous struct")
 
     def test_anon_array_index_access(self, fprime_test_api):
-        """Index into an anonymous array literal with a constant index."""
         seq = """
 x: U32 = [1, 2, 3][1]
-assert x == 2
 """
-        assert_run_success(fprime_test_api, seq)
+        assert_compile_failure(fprime_test_api, seq, match="anonymous array")
 
-    def test_anon_array_index_out_of_bounds(self, fprime_test_api):
-        """Out-of-bounds index on anonymous array should fail."""
-        seq = """
-x: U32 = [1, 2, 3][3]
-"""
-        assert_compile_failure(fprime_test_api, seq)
-
-    def test_anon_struct_member_access_with_variable(self, fprime_test_api):
-        """Access member of anon struct where member value is a runtime variable."""
+    def test_ctor_member_access(self, fprime_test_api):
+        """The constructor call an anonymous struct stands for can be accessed."""
         seq = """
 y: U32 = 42
-x: U32 = {a: y}.a
+x: U32 = Fw.TimeIntervalValue(seconds=y).seconds
 assert x == 42
 """
         assert_run_success(fprime_test_api, seq)
-
-    def test_anon_array_dynamic_index_fails(self, fprime_test_api):
-        """Dynamic (non-constant) indexing on anonymous array should fail."""
-        seq = """
-i: I64 = 1
-x: U32 = [10, 20, 30][i]
-"""
-        assert_compile_failure(fprime_test_api, seq)
 
 
 # ── Anonymous expressions in check statements ───────────────────────────

--- a/test/fpy/test_anon_exprs.py
+++ b/test/fpy/test_anon_exprs.py
@@ -212,6 +212,22 @@ val: Svc.ComQueueDepth = [True, False]
 """
         assert_compile_failure(fprime_test_api, seq)
 
+    def test_anon_array_wrong_element_type_as_func_arg(self, fprime_test_api):
+        """An argument's coercibility is checked by its array type alone when
+        binding arguments; the elements are checked when it is coerced."""
+        seq = """
+def first(a: Svc.ComQueueDepth) -> U32:
+    return a[0]
+x: U32 = first([True, False])
+"""
+        assert_compile_failure(fprime_test_api, seq, match="Expected U32, found bool")
+
+    def test_anon_array_wrong_element_type_as_ctor_arg(self, fprime_test_api):
+        seq = """
+v: Ref.SignalInfo = Ref.SignalInfo(Ref.SignalType.TRIANGLE, [True], [])
+"""
+        assert_compile_failure(fprime_test_api, seq, match="Expected F32, found bool")
+
     def test_anon_array_assigned_to_non_array(self, fprime_test_api):
         """Anonymous array cannot be coerced to a non-array type."""
         seq = """

--- a/test/fpy/test_anon_exprs.py
+++ b/test/fpy/test_anon_exprs.py
@@ -82,7 +82,7 @@ val: Fw.TimeIntervalValue = {seconds: True}
         seq = """
 val: U32 = {seconds: 1}
 """
-        assert_compile_failure(fprime_test_api, seq, match="found anonymous struct")
+        assert_compile_failure(fprime_test_api, seq, match="found struct literal")
 
     def test_anon_struct_bare_statement(self, fprime_test_api):
         """An anonymous struct not coerced to any type has no constructor to
@@ -90,14 +90,14 @@ val: U32 = {seconds: 1}
         seq = """
 {seconds: 1}
 """
-        assert_compile_failure(fprime_test_api, seq, match="Anonymous struct")
+        assert_compile_failure(fprime_test_api, seq, match="Cannot infer the type")
 
     def test_anon_struct_sized_arg(self, fprime_test_api):
         """A parameter accepting any sized value gives an anon struct no type."""
         seq = """
 write_to_port(Svc.Fpy.SerialPortIndex.EXAMPLE_PORT_0, {seconds: 1})
 """
-        assert_compile_failure(fprime_test_api, seq, match="found anonymous struct")
+        assert_compile_failure(fprime_test_api, seq, match="found struct literal")
 
 
 class TestAnonStructAdvanced:
@@ -217,8 +217,7 @@ val: Svc.ComQueueDepth = [True, False]
         seq = """
 val: U32 = [1, 2, 3]
 """
-        # FIXME yeah let's remove the word anonymous from the err msgs
-        assert_compile_failure(fprime_test_api, seq, match="found anonymous array")
+        assert_compile_failure(fprime_test_api, seq, match="found array literal")
 
     def test_anon_array_bare_statement(self, fprime_test_api):
         """An anonymous array not coerced to any type has no constructor to
@@ -226,7 +225,7 @@ val: U32 = [1, 2, 3]
         seq = """
 [1, 2]
 """
-        assert_compile_failure(fprime_test_api, seq, match="Anonymous array")
+        assert_compile_failure(fprime_test_api, seq, match="Cannot infer the type")
 
     def test_anon_array_incompatible_element_types(self, fprime_test_api):
         """Each element is coerced to the target's element type."""
@@ -298,23 +297,61 @@ assert val.history[3] == 4.0
 
 
 class TestAnonDirectAccess:
-    """An anonymous literal only gets a type from the context it is coerced
-    in, so there is no type to access a member or element of."""
+    """Member/index access directly on an anonymous literal used to be
+    supported: the literal was typed from its own members, and the access
+    emitted just the accessed member's expression. An anonymous literal now
+    only gets a type from the context it is coerced in, so there is no type
+    to access a member or element of, and every such access is an error.
 
-    # FIXME just keep the old tests around, just have them fail, explain it's to check if in the future
-    # we ever go back to old anon semantics
+    The old tests are kept, asserting failure, so that a future return to the
+    old semantics shows up here."""
 
     def test_anon_struct_member_access(self, fprime_test_api):
+        """Access a specific member from an anonymous struct literal."""
         seq = """
 a: U32 = {x: 10, y: 20, z: 30}.y
+assert a == 20
 """
-        assert_compile_failure(fprime_test_api, seq, match="anonymous struct")
+        assert_compile_failure(fprime_test_api, seq, match="struct literal")
+
+    def test_anon_struct_member_access_nonexistent(self, fprime_test_api):
+        """Accessing a non-existent member should fail."""
+        seq = """
+x: U32 = {xyz: 123}.abc
+"""
+        assert_compile_failure(fprime_test_api, seq, match="struct literal")
 
     def test_anon_array_index_access(self, fprime_test_api):
+        """Index into an anonymous array literal with a constant index."""
         seq = """
 x: U32 = [1, 2, 3][1]
+assert x == 2
 """
-        assert_compile_failure(fprime_test_api, seq, match="anonymous array")
+        assert_compile_failure(fprime_test_api, seq, match="array literal")
+
+    def test_anon_array_index_out_of_bounds(self, fprime_test_api):
+        """Out-of-bounds index on anonymous array should fail."""
+        seq = """
+x: U32 = [1, 2, 3][3]
+"""
+        assert_compile_failure(fprime_test_api, seq, match="array literal")
+
+    def test_anon_struct_member_access_with_variable(self, fprime_test_api):
+        """Access member of anon struct where member value is a runtime variable."""
+        seq = """
+y: U32 = 42
+x: U32 = {a: y}.a
+assert x == 42
+"""
+        assert_compile_failure(fprime_test_api, seq, match="struct literal")
+
+    def test_anon_array_dynamic_index_fails(self, fprime_test_api):
+        """Dynamic (non-constant) indexing on anonymous array should fail."""
+        seq = """
+i: I64 = 1
+x: U32 = [10, 20, 30][i]
+"""
+        assert_compile_failure(fprime_test_api, seq, match="array literal")
 
     def test_ctor_member_access(self, fprime_test_api):
         """The constructor call an anonymous struct stands for can be accessed."""

--- a/test/fpy/test_dictionary.py
+++ b/test/fpy/test_dictionary.py
@@ -2463,13 +2463,13 @@ class TestSingleValueArrayInitIntegration:
     def _get_type_scope(self):
         from fpy.state import _build_global_scopes
 
-        type_scope, _, _, _ = _build_global_scopes(REF_DICT_PATH)
+        type_scope, _, _, _, _ = _build_global_scopes(REF_DICT_PATH)
         return type_scope
 
     def _get_callable_scope(self):
         from fpy.state import _build_global_scopes
 
-        _, callable_scope, _, _ = _build_global_scopes(REF_DICT_PATH)
+        _, callable_scope, _, _, _ = _build_global_scopes(REF_DICT_PATH)
         return callable_scope
 
     def _lookup_type(self, name: str) -> FpyType:
@@ -3140,13 +3140,13 @@ class TestTypeCtorDefaults:
     def _get_callable_scope(self):
         from fpy.state import _build_global_scopes
 
-        _, callable_scope, _, _ = _build_global_scopes(REF_DICT_PATH)
+        _, callable_scope, _, _, _ = _build_global_scopes(REF_DICT_PATH)
         return callable_scope
 
     def _get_type_scope(self):
         from fpy.state import _build_global_scopes
 
-        type_scope, _, _, _ = _build_global_scopes(REF_DICT_PATH)
+        type_scope, _, _, _, _ = _build_global_scopes(REF_DICT_PATH)
         return type_scope
 
     def _lookup_callable(self, name: str):

--- a/test/fpy/test_functions.py
+++ b/test/fpy/test_functions.py
@@ -944,3 +944,35 @@ assert x == 0
         assert_run_success(
             fprime_test_api, seq, expected_warnings={WarningType.SHADOW_CALLABLE}
         )
+
+
+class TestCalleeMustBeCallable:
+    """A call's callee must resolve to a callable. Anything else -- a value
+    or an expression -- is rejected as an unknown callable before type
+    checking, so the type pass never sees an unresolved callee."""
+
+    def test_call_of_call_result(self, fprime_test_api):
+        assert_compile_failure(fprime_test_api, "now()()\n", match="Unknown callable")
+
+    def test_call_of_literal(self, fprime_test_api):
+        assert_compile_failure(fprime_test_api, "(1)()\n", match="Unknown callable")
+
+    def test_call_of_variable(self, fprime_test_api):
+        seq = """
+x: U32 = 1
+x()
+"""
+        assert_compile_failure(fprime_test_api, seq, match="Unknown callable 'x'")
+
+    def test_call_of_array_element(self, fprime_test_api):
+        seq = """
+a: Svc.ComQueueDepth = [1, 2]
+a[0]()
+"""
+        assert_compile_failure(fprime_test_api, seq, match="Unknown callable")
+
+    def test_call_of_member_of_call(self, fprime_test_api):
+        seq = """
+x: U32 = Fw.TimeIntervalValue(1, 0).seconds()
+"""
+        assert_compile_failure(fprime_test_api, seq, match="Unknown callable")

--- a/test/fpy/test_parsing.py
+++ b/test/fpy/test_parsing.py
@@ -236,32 +236,32 @@ assert val.useconds == 500
     def test_multiline_anon_array(self, fprime_test_api):
         """Anon array split over multiple lines."""
         seq = """
-x: U32 = [
+x: Ref.DpDemo.U32Array = [
     10,
     20,
     30
-][1]
-assert x == 20
+]
+assert x[1] == 20
 """
         assert_run_success(fprime_test_api, seq)
 
     def test_multiline_anon_array_trailing_comma(self, fprime_test_api):
         """Anon array split over multiple lines with trailing comma."""
         seq = """
-x: U32 = [
+x: Ref.DpDemo.U32Array = [
     10,
     20,
     30,
-][1]
-assert x == 20
+]
+assert x[1] == 20
 """
         assert_run_success(fprime_test_api, seq)
 
     def test_trailing_comma_anon_array_single_line(self, fprime_test_api):
         """Trailing comma on a single-line anon array."""
         seq = """
-x: U32 = [10, 20, 30,][1]
-assert x == 20
+x: Ref.DpDemo.U32Array = [10, 20, 30,]
+assert x[1] == 20
 """
         assert_run_success(fprime_test_api, seq)
 
@@ -828,7 +828,7 @@ class TestMultilineConstructorsWithoutBackslash:
     def test_nested_multiline_constructor(self, fprime_test_api):
         seq = (
             "v: Fw.TimeIntervalValue = Fw.TimeIntervalValue(\n"
-            "    [10, 20, 30][0],\n"
+            "    Svc.ComQueueDepth(10, 20)[0],\n"
             "    500,\n"
             ")\n"
             "assert v.seconds == 10\n"

--- a/test/fpy/test_seq_calling.py
+++ b/test/fpy/test_seq_calling.py
@@ -56,7 +56,7 @@ class TestSeqRunDetection:
 
         _build_global_scopes.cache_clear()
         load_dictionary.cache_clear()
-        _, callable_scope, _, _ = _build_global_scopes(default_dictionary)
+        _, callable_scope, _, _, _ = _build_global_scopes(default_dictionary)
 
         # Navigate to Ref.seqDisp.RUN_ARGS
         sym = callable_scope["Ref"]["seqDisp"]["RUN_ARGS"]
@@ -74,7 +74,7 @@ class TestSeqRunDetection:
 
         _build_global_scopes.cache_clear()
         load_dictionary.cache_clear()
-        _, callable_scope, _, _ = _build_global_scopes(default_dictionary)
+        _, callable_scope, _, _, _ = _build_global_scopes(default_dictionary)
 
         sym = callable_scope["Ref"]["seqDisp"]["RUN"]
         assert isinstance(sym, CommandSymbol)
@@ -720,7 +720,7 @@ class TestSeqArgsBufferSizeFromDictionary:
             dict_path = _dict_with_seq_args_buffer_size(1024, Path(tmpdir))
             _build_global_scopes.cache_clear()
             load_dictionary.cache_clear()
-            _, _, _, type_defs = _build_global_scopes(dict_path)
+            _, _, _, type_defs, _ = _build_global_scopes(dict_path)
             seq_args = type_defs["Svc.SeqArgs"]
             assert seq_args.members[1].type.length == 1024
             assert seq_args.members[1].type.name == "Array_U8_1024"

--- a/test/fpy/test_wasm.py
+++ b/test/fpy/test_wasm.py
@@ -347,14 +347,14 @@ class TestWasmMemberAccess:
             == DOMAIN_ERROR
         )
 
-    def test_anon_struct_member(self):
-        # Member access on an anonymous struct literal emits just the member
-        # expression; a runtime member value keeps it from const-folding.
+    def test_anon_struct_runtime_member(self):
+        # An anonymous struct is a constructor call of its target type; a
+        # runtime member value keeps it from const-folding.
         assert (
             run_seq_wasm(
                 "y: F32 = 4.5\n"
-                "x: F32 = {time: 1.0, value: y}.value\n"
-                "assert x == 4.5\n"
+                "p: Ref.SignalPair = {time: 1.0, value: y}\n"
+                "assert p.value == 4.5\n"
             )
             == NO_ERROR
         )


### PR DESCRIPTION
* Significantly simplify codegen and late semantic passes by desugaring anon exprs instead of keeping them around
* They desugar to type ctor calls