### PR TITLE
Use FwSizeStoreType from dict for directive serialization

### DIFF
--- a/src/fpy/bytecode/directives.py
+++ b/src/fpy/bytecode/directives.py
@@ -11,7 +11,6 @@ from fpy.types import (
     TypeKind,
     FwSizeStoreType,
     U8,
-    U16,
     U32,
     U64,
     I8,
@@ -259,7 +258,7 @@ class Directive:
     def serialize(self) -> bytes:
         arg_bytes = self.serialize_args()
         output = FpyValue(U8, self.opcode.value).serialize()
-        output += FpyValue(U16, len(arg_bytes)).serialize()
+        output += FpyValue(FwSizeStoreType, len(arg_bytes)).serialize()
         output += arg_bytes
         return output
 
@@ -293,11 +292,12 @@ class Directive:
 
     @classmethod
     def deserialize(cls, data: bytes, offset: int) -> tuple[int, Directive] | None:
-        if len(data) - offset < 3:
+        header_size = U8.max_size + FwSizeStoreType.max_size
+        if len(data) - offset < header_size:
             return None
         opcode = struct.unpack_from(">B", data, offset)[0]
-        arg_size = struct.unpack_from(">H", data, offset + 1)[0]
-        offset += 3
+        arg_size = FpyValue.deserialize(FwSizeStoreType, data, offset + 1)[0].val
+        offset += header_size
         if len(data) - offset < arg_size:
             return None
         args = data[offset : (offset + arg_size)]

--- a/test/fpy/test_dictionary.py
+++ b/test/fpy/test_dictionary.py
@@ -3348,15 +3348,25 @@ class TestTypeAliasesFromDict:
         )
 
     def test_size_store_type_default_then_updated(self):
-        from fpy.bytecode.directives import update_configurable_types_from_dict
+        from fpy.bytecode.directives import (
+            Directive,
+            PushValDirective,
+            update_configurable_types_from_dict,
+        )
         from fpy.types import FwSizeStoreType
 
         string_type = FpyType(TypeKind.STRING, "String_10", max_length=10)
+        # A directive's argument byte count is also an FwSizeStoreType.
+        push_val = PushValDirective(b"\x01\x02\x03")
+        push_val_opcode = FpyValue(U8, push_val.opcode.value).serialize()
 
         # Default string length prefix is U16.
         assert FwSizeStoreType.kind == TypeKind.U16
         assert FpyValue(string_type, "hi").serialize() == (
             FpyValue(U16, 2).serialize() + b"hi"
+        )
+        assert push_val.serialize() == (
+            push_val_opcode + FpyValue(U16, 3).serialize() + b"\x01\x02\x03"
         )
 
         update_configurable_types_from_dict({"FwSizeStoreType": U8})
@@ -3364,6 +3374,10 @@ class TestTypeAliasesFromDict:
         assert FpyValue(string_type, "hi").serialize() == (
             FpyValue(U8, 2).serialize() + b"hi"
         )
+        assert push_val.serialize() == (
+            push_val_opcode + FpyValue(U8, 3).serialize() + b"\x01\x02\x03"
+        )
+        assert Directive.deserialize(push_val.serialize(), 0) == (5, push_val)
 
     def test_custom_dictionary_redefines_types_end_to_end(self):
         """A custom dictionary that redefines the Fw* aliases is picked up by the


### PR DESCRIPTION
* FwSizeStoreType is correctly used in directive serialization