### PR TITLE
Configurable default time base

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ array_var: Ref.DpDemo.U32Array = [0, 1, 2, 3, 4]
 struct_var: Fw.TimeInterval = {seconds: 0, useconds: 1000}
 ```
 
-If a struct or array has a default value for a member/element, it will use that default value if you don't provide one.
+If a struct or array has a default value for a member/element, it will use that default value if you don't provide one. The default `timeBase` of an `Fw.TimeValue` is overridden to `TimeBase.TB_WORKSTATION_TIME`. You can configure this by passing the `--time-base` flag.
 
 Trailing commas are allowed in these expressions.
 
@@ -520,7 +520,7 @@ log("checkTimers called!")
 
 log("today")
 # sleep until 1234567890 seconds and 0 microseconds after the epoch
-sleep_until({timeBase: TimeBase.TB_NONE, timeContext: 1, seconds: 1234567890, useconds: 0})
+sleep_until({seconds: 1234567890, useconds: 0})
 log("much later")
 ```
 
@@ -533,8 +533,8 @@ sleep_until(time("2025-12-19T14:30:00Z"))
 t: Fw.Time = time("2025-12-19T14:30:00.123456Z")
 sleep_until(t)
 
-# Customize timeBase and timeContext (defaults are TimeBase.TB_NONE and 0)
-t: Fw.Time = time("2025-12-19T14:30:00Z", timeBase=TimeBase.TB_WORKSTATION_TIME, timeContext=1)
+# Customize timeBase and timeContext (defaults are TimeBase.TB_WORKSTATION_TIME and 0)
+t: Fw.Time = time("2025-12-19T14:30:00Z", timeBase=TimeBase.TB_SC_TIME, timeContext=1)
 ```
 
 Make sure that the `Svc.FpySequencer.checkTimers` port is connected to a rate group. The sequencer only checks if a sleep is done when the port is called, so the more frequently you call it, the more accurate the wakeup time.

--- a/src/fpy/macros.py
+++ b/src/fpy/macros.py
@@ -363,6 +363,8 @@ TIME_MACRO = BuiltinFuncSymbol(
     TIME,
     [
         ("timestamp", INTERNAL_STRING, None),
+        # placeholder; get_base_compile_state installs the configured
+        # default time base
         ("timeBase", TIME_BASE, FpyValue(TIME_BASE, "TB_NONE")),
         ("timeContext", U8, FpyValue(U8, 0)),
     ],

--- a/src/fpy/main.py
+++ b/src/fpy/main.py
@@ -30,6 +30,7 @@ from fpy.compiler import (
     analysis_to_fpybc_directives,
 )
 from fpy.state import get_base_compile_state
+from fpy.types import DEFAULT_TIME_BASE
 from fpy.error import parse_warning_set
 
 
@@ -75,6 +76,21 @@ def parse_seq_maps(specs: list[str]) -> list[tuple[str, str]]:
         bin_prefix, fpy_prefix = spec.split("=", 1)
         maps.append((bin_prefix, fpy_prefix))
     return maps
+
+
+def _add_time_base_argument(arg_parser: argparse.ArgumentParser):
+    arg_parser.add_argument(
+        "--time-base",
+        type=str,
+        default=DEFAULT_TIME_BASE,
+        metavar="CONSTANT",
+        dest="time_base",
+        help=(
+            "TimeBase enum constant used as the default timeBase of time() "
+            f"and of the Fw.TimeValue constructor (default: {DEFAULT_TIME_BASE}). "
+            "Must be a constant of the dictionary's TimeBase enum."
+        ),
+    )
 
 
 def _add_seq_map_argument(arg_parser: argparse.ArgumentParser):
@@ -137,6 +153,7 @@ def compile_main(args: list[str] = None):
         help="Pass this to print out compiler debugging information",
     )
     _add_seq_map_argument(arg_parser)
+    _add_time_base_argument(arg_parser)
     arg_parser.add_argument(
         "-i",
         "--imports",
@@ -210,6 +227,7 @@ def compile_main(args: list[str] = None):
             import_directories=import_directories,
             main_file_dir=str(parsed_args.input.parent.resolve()),
             main_file_path=str(parsed_args.input.resolve()),
+            default_time_base=parsed_args.time_base,
         )
     except fpy.error.DictionaryError as e:
         print(e, file=sys.stderr)
@@ -452,6 +470,7 @@ def cmd_main(args: list[str] = None):
         help="The FPrime dictionary .json file",
     )
     _add_seq_map_argument(arg_parser)
+    _add_time_base_argument(arg_parser)
     arg_parser.add_argument(
         "--zmq-addr",
         type=str,
@@ -498,6 +517,7 @@ def cmd_main(args: list[str] = None):
         state = get_base_compile_state(
             str(parsed_args.dictionary.resolve()),
             seq_maps,
+            default_time_base=parsed_args.time_base,
         )
     except fpy.error.DictionaryError as e:
         print(e, file=sys.stderr)

--- a/src/fpy/state.py
+++ b/src/fpy/state.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 import fpy.types
 from fpy.dictionary import json_default_to_fpy_value, load_dictionary
 from fpy.error import CompileError, CompileWarning, DictionaryError, WarningType
-from fpy.macros import MACROS
+from fpy.macros import MACROS, TIME_MACRO
 from fpy.symbols import (
     CallableSymbol,
     CastSymbol,
@@ -46,6 +46,7 @@ from fpy.types import (
     DEFAULT_MAX_DIRECTIVE_SIZE,
     DEFAULT_MAX_SEQ_ARG_COUNT,
     DEFAULT_MAX_STACK_SIZE,
+    DEFAULT_TIME_BASE,
     FLAGS_TYPE,
     I64,
     LOG_SEVERITY,
@@ -540,11 +541,13 @@ def _make_type_ctor(name: str, typ: FpyType) -> TypeCtorSymbol | None:
 
 
 @lru_cache(maxsize=4)
-def _build_global_scopes(dictionary: str) -> tuple:
+def _build_global_scopes(
+    dictionary: str, default_time_base: str = DEFAULT_TIME_BASE
+) -> tuple:
     """
     Build and cache the 3 global scopes, type_name_dict and type_ctors for a
-    dictionary. Returns tuple of (type_scope, callable_scope, values_scope,
-    type_name_dict, type_ctors).
+    (dictionary, default time base) pair. Returns tuple of (type_scope,
+    callable_scope, values_scope, type_name_dict, type_ctors).
     """
     d = load_dictionary(dictionary)
     cmd_name_dict = d["cmd_name_dict"]
@@ -558,6 +561,12 @@ def _build_global_scopes(dictionary: str) -> tuple:
 
     # Validate required dictionary types
     _update_time_base_from_dict(dict_type_name_dict)
+    if default_time_base not in TIME_BASE.enum_dict:
+        raise DictionaryError(
+            "TimeBase",
+            f"The default time base {default_time_base!r} is not one of its "
+            f"constants: {', '.join(TIME_BASE.enum_dict)}.",
+        )
     _update_time_context_type_from_dict(dict_type_name_dict)
     _validate_and_replace_type(dict_type_name_dict, "Fw.TimeValue", TIME)
     _validate_and_replace_type(
@@ -609,6 +618,11 @@ def _build_global_scopes(dictionary: str) -> tuple:
     # Populate per-member/per-element defaults on types before building ctors
     for typ in type_name_dict.values():
         _populate_type_defaults(typ)
+
+    # The default time base supersedes the dictionary's timeBase default for
+    # the Fw.TimeValue ctor (struct literals coerce through the ctor, so they
+    # inherit it too).
+    TIME.member_defaults["timeBase"] = FpyValue(TIME_BASE, default_time_base)
 
     # Build callable dict: commands, numeric casts, type constructors, macros
     callable_name_dict: dict[str, CallableSymbol] = {}
@@ -675,11 +689,18 @@ def get_base_compile_state(
     import_directories: list[str] | None = None,
     main_file_dir: str | None = None,
     main_file_path: str | None = None,
+    default_time_base: str | None = None,
 ) -> CompileState:
     """return the initial state of the compiler, based on the given dict path"""
+    if default_time_base is None:
+        default_time_base = DEFAULT_TIME_BASE
     type_scope, callable_scope, values_scope, type_defs, type_ctors = (
-        _build_global_scopes(dictionary)
+        _build_global_scopes(dictionary, default_time_base)
     )
+    # time() is a module-level symbol shared by every cached scope set, so its
+    # timeBase default is reapplied on every call: a _build_global_scopes cache
+    # hit must still reflect this compile's default time base.
+    TIME_MACRO.args[1] = ("timeBase", TIME_BASE, FpyValue(TIME_BASE, default_time_base))
     constants = load_dictionary(dictionary)["constants"]
 
     def _const_int(key: str, default: int | None) -> int | None:

--- a/src/fpy/types.py
+++ b/src/fpy/types.py
@@ -32,6 +32,10 @@ DEFAULT_MAX_DIRECTIVE_SIZE = 2048
 DEFAULT_MAX_SEQ_ARG_COUNT = 16
 DEFAULT_MAX_STACK_SIZE = 65535
 
+# The TimeBase constant used as the default timeBase of time() and of the
+# Fw.TimeValue constructor - may be overridden via get_base_compile_state.
+DEFAULT_TIME_BASE = "TB_WORKSTATION_TIME"
+
 # Keep old names as aliases for backward compatibility
 MAX_DIRECTIVES_COUNT = DEFAULT_MAX_DIRECTIVES_COUNT
 MAX_DIRECTIVE_SIZE = DEFAULT_MAX_DIRECTIVE_SIZE

--- a/test/fpy/test_compiler_config.py
+++ b/test/fpy/test_compiler_config.py
@@ -549,6 +549,54 @@ t: Fw.Time = Fw.Time(TimeBase.TB_SC_TIME, 0, 100, 0)
     analysis_to_fpybc_directives(state)
 
 
+def test_default_time_base():
+    """The default time base is the timeBase default of the Fw.TimeValue ctor
+    and of time()."""
+    _clear_caches()
+    from fpy.macros import TIME_MACRO
+    from fpy.types import TIME
+
+    state = get_base_compile_state(DEFAULT_DICTIONARY)
+
+    assert state.type_ctors[TIME].args[0][2].val == "TB_WORKSTATION_TIME"
+    assert TIME_MACRO.args[1][2].val == "TB_WORKSTATION_TIME"
+
+
+def test_default_time_base_override():
+    """default_time_base overrides the timeBase default, and a subsequent
+    compile with a different choice is not affected by the cached scopes."""
+    _clear_caches()
+    from fpy.macros import TIME_MACRO
+    from fpy.types import TIME
+
+    state = get_base_compile_state(DEFAULT_DICTIONARY, default_time_base="TB_SC_TIME")
+    assert state.type_ctors[TIME].args[0][2].val == "TB_SC_TIME"
+    assert TIME_MACRO.args[1][2].val == "TB_SC_TIME"
+
+    state = get_base_compile_state(DEFAULT_DICTIONARY)
+    assert state.type_ctors[TIME].args[0][2].val == "TB_WORKSTATION_TIME"
+    assert TIME_MACRO.args[1][2].val == "TB_WORKSTATION_TIME"
+
+    # This hits the cache from the first call; time()'s default must follow.
+    state = get_base_compile_state(DEFAULT_DICTIONARY, default_time_base="TB_SC_TIME")
+    assert state.type_ctors[TIME].args[0][2].val == "TB_SC_TIME"
+    assert TIME_MACRO.args[1][2].val == "TB_SC_TIME"
+
+    _clear_caches()
+
+
+def test_default_time_base_not_in_dictionary_raises_error():
+    """A default time base that is not a constant of the dictionary's TimeBase
+    enum raises an error."""
+    _clear_caches()
+    from fpy.error import DictionaryError
+
+    with pytest.raises(DictionaryError, match="not one of its constants"):
+        get_base_compile_state(DEFAULT_DICTIONARY, default_time_base="TB_BOGUS")
+
+    _clear_caches()
+
+
 # ============================================================================
 # FpySequencer limit checks: MAX_SEQUENCE_ARG_COUNT, MAX_STACK_SIZE,
 # MAX_DIRECTIVE_SIZE, FW_COM_BUFFER_MAX_SIZE, FW_CMD_ARG_BUFFER_MAX_SIZE

--- a/test/fpy/test_integration.py
+++ b/test/fpy/test_integration.py
@@ -63,6 +63,10 @@ else:
 
 time_interval: Fw.TimeInterval = {seconds: 15, useconds: 1000}
 
+# README: the default timeBase of an Fw.TimeValue is TimeBase.TB_WORKSTATION_TIME
+default_tb: Fw.Time = {timeContext: 0, seconds: 100, useconds: 0}
+assert default_tb.timeBase == TimeBase.TB_WORKSTATION_TIME
+
 array_var: Ref.DpDemo.U32Array = [0, 1, 2, 3, 4]
 
 enum_var: Fw.Enabled = Fw.Enabled.ENABLED
@@ -199,7 +203,7 @@ if success == Fw.CmdResponse.OK:
     log("No-op works!")
 
 parsed_time: Fw.Time = time("2025-12-19T14:30:00.123456Z")
-parsed_time_with_base: Fw.Time = time("2025-12-19T14:30:00Z", timeBase=TimeBase.TB_WORKSTATION_TIME, timeContext=1)
+parsed_time_with_base: Fw.Time = time("2025-12-19T14:30:00Z", timeBase=TimeBase.TB_SC_TIME, timeContext=1)
 
 # Logging
 log("hello world!")

--- a/test/fpy/test_main.py
+++ b/test/fpy/test_main.py
@@ -201,6 +201,33 @@ def test_compile_main_no_includes_means_no_import_directories(monkeypatch, tmp_p
     assert captured_kwargs["main_file_dir"] == str(input_path.parent.resolve())
 
 
+def test_compile_main_time_base(monkeypatch, tmp_path):
+    """--time-base is forwarded as default_time_base; without the flag the
+    default is TB_WORKSTATION_TIME."""
+    input_path = tmp_path / "seq.fpy"
+    input_path.write_text("content")
+    dict_path = tmp_path / "dict.json"
+    dict_path.write_text("{}")
+
+    captured_kwargs = _run_compile_capturing_kwargs(
+        monkeypatch,
+        [str(input_path), "--dictionary", str(dict_path)],
+    )
+    assert captured_kwargs["default_time_base"] == "TB_WORKSTATION_TIME"
+
+    captured_kwargs = _run_compile_capturing_kwargs(
+        monkeypatch,
+        [
+            str(input_path),
+            "--dictionary",
+            str(dict_path),
+            "--time-base",
+            "TB_SC_TIME",
+        ],
+    )
+    assert captured_kwargs["default_time_base"] == "TB_SC_TIME"
+
+
 def test_compile_main_missing_input(tmp_path, capsys):
     missing = tmp_path / "missing.fpy"
     dict_path = tmp_path / "dict.json"

--- a/test/fpy/test_time_seqs.py
+++ b/test/fpy/test_time_seqs.py
@@ -1181,11 +1181,22 @@ t: Fw.Time = time("2000-01-01T00:00:00")
         assert_compile_failure(fprime_test_api, seq)
 
     def test_time_function_default_time_base(self, fprime_test_api):
-        """time() defaults to timeBase=0 and timeContext=0."""
+        """time() defaults to timeBase=TB_WORKSTATION_TIME and timeContext=0."""
         seq = """
 t: Fw.Time = time("2000-01-01T00:00:00Z")
-assert t.timeBase == TimeBase.TB_NONE
+assert t.timeBase == TimeBase.TB_WORKSTATION_TIME
 assert t.timeContext == 0
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_time_ctor_default_time_base(self, fprime_test_api):
+        """Fw.TimeValue's timeBase defaults to TB_WORKSTATION_TIME, including
+        through a struct literal that omits it."""
+        seq = """
+t: Fw.Time = Fw.TimeValue()
+assert t.timeBase == TimeBase.TB_WORKSTATION_TIME
+u: Fw.Time = {timeContext: 1, seconds: 5, useconds: 0}
+assert u.timeBase == TimeBase.TB_WORKSTATION_TIME
 """
         assert_run_success(fprime_test_api, seq)
 
@@ -1202,7 +1213,7 @@ assert t.timeContext == 0
         """time() accepts custom timeContext parameter."""
         seq = """
 t: Fw.Time = time("2000-01-01T00:00:00Z", timeContext=5)
-assert t.timeBase == TimeBase.TB_NONE
+assert t.timeBase == TimeBase.TB_WORKSTATION_TIME
 assert t.timeContext == 5
 """
         assert_run_success(fprime_test_api, seq)


### PR DESCRIPTION
* Sets the default time base to TB_WORKSTATION_TIME for time() func and Time/TimeValue constructors
* Default time base is configurable via cli flag