### PR TITLE
Default period 0 seconds for check stmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ check CdhCore.cmdDisp.CommandsDispatched > 30 timeout never period {seconds: 1}:
     log("more than 30 commands!")
 ```
 
-If you don't specify a value for `period`, the default period is 1 second.
+If you don't specify a value for `period`, the default period is 0 seconds, so the condition is checked on every checkTimers call.
 
 The `timeout`, `persist` and `period` clauses can appear in any order. They can also be spread across multiple lines:
 ```py

--- a/SPEC.md
+++ b/SPEC.md
@@ -650,7 +650,7 @@ If `persist` or `freq` is provided, and they cannot be coerced to [`Fw.TimeInter
 At execution:
 1. `persist` and `freq` are evaluated and stored. If `timeout` is not `never`, it is evaluated as a relative interval and the timeout deadline is stored as that interval added to the current time.
 2. If `persist` is not provided, its stored value is a zero-duration `Fw.TimeIntervalValue`.
-3. If `freq` is not provided, its stored value is a one-second `Fw.TimeIntervalValue`.
+3. If `freq` is not provided, its stored value is a zero-duration `Fw.TimeIntervalValue`.
 4. If `timeout` is not `never` and the current time is [greater](todo) than the stored timeout deadline, the check times out.
 5. Evaluate `condition`.
 6. If `condition` has evaluated to `True` for duration greater than or equal to `persist`'s stored value, execute `body`, then continue execution after the check statement.

--- a/src/fpy/desugaring.py
+++ b/src/fpy/desugaring.py
@@ -404,7 +404,7 @@ class DesugarCheckStatements(Transformer):
     Default values:
         - timeout: no timeout (runs indefinitely until condition persists)
         - persist: 0 second interval (condition must be true once)
-        - period: 1 second interval (check condition every second)
+        - period: 0 second interval (check condition on every checkTimers call)
 
     Gets desugared into (roughly):
         # timeout deadline computed once, at entry, from the relative interval:
@@ -533,7 +533,7 @@ class DesugarCheckStatements(Transformer):
 
         # Handle default values:
         # - persist: default to Fw.TimeIntervalValue(0, 0) (0 second interval)
-        # - period: default to Fw.TimeIntervalValue(1, 0) (1 second interval)
+        # - period: default to Fw.TimeIntervalValue(0, 0) (0 second interval)
         # - timeout: if not specified, use a dummy value (but we skip timeout check logic)
 
         persist_expr = (
@@ -548,7 +548,7 @@ class DesugarCheckStatements(Transformer):
             copy.deepcopy(node.period)
             if node.period is not None
             else self.call_parts(
-                ["Fw", "TimeIntervalValue"], self.number(1), self.number(0)
+                ["Fw", "TimeIntervalValue"], self.number(0), self.number(0)
             )
         )
 

--- a/src/fpy/syntax.py
+++ b/src/fpy/syntax.py
@@ -307,7 +307,7 @@ class AstCheck(Ast):
     condition: AstExpr
     timeout: Union[AstExpr, None]  # The timeout interval, or None if `never`/absent
     persist: Union[AstExpr, None]  # Default: 0 second interval
-    period: Union[AstExpr, None]  # Default: 1 second interval
+    period: Union[AstExpr, None]  # Default: 0 second interval
     body: Union["AstBlock", None]  # None for body-less check
     timeout_body: Union["AstBlock", None] = None
     timeout_never: bool = False  # True if the timeout clause is `never`

--- a/test/fpy/test_check.py
+++ b/test/fpy/test_check.py
@@ -132,12 +132,31 @@ assert timeout_body_ran
 class TestCheckClauses:
 
     def test_check_only_timeout_specified(self, fprime_test_api):
-        """Test check with only timeout specified (uses default persist=0 and period=1s)."""
+        """Test check with only timeout specified (uses default persist=0 and period=0)."""
         seq = """
 check True timeout Fw.TimeIntervalValue(1, 0):
     exit(0)
 timeout:
     assert False, 1
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_check_default_period_is_zero(self, fprime_test_api):
+        """Test that a check without a period clause re-checks on the next checkTimers call, not after 1 second."""
+        seq = """
+calls: I64 = 0
+
+def second_call() -> bool:
+    calls = calls + 1
+    return calls >= 2
+
+start: Fw.Time = now()
+check second_call() timeout Fw.TimeIntervalValue(5, 0):
+    pass
+timeout:
+    assert False, 1
+elapsed: Fw.TimeIntervalValue = time_sub(now(), start)
+assert elapsed.seconds == 0
 """
         assert_run_success(fprime_test_api, seq)
 

--- a/test/harness/FpySequencerTester.cpp
+++ b/test/harness/FpySequencerTester.cpp
@@ -126,12 +126,18 @@ void FpySequencerTester::pump() {
             State state = seq.sequencer_getState();
             if (state == State::RUNNING_SLEEPING) {
                 // Jump the clock to the wake-up time instead of waiting, then
-                // let the sequencer check its timers. On a time base mismatch
-                // the clock is left alone; the sequencer will fail the
-                // sequence itself when it compares the times.
+                // let the sequencer check its timers. A wake-up time that has
+                // already come (a zero-duration sleep) resumes on the next
+                // checkTimers call, one CHECK_TIMERS_PERIOD_USEC later. On a
+                // time base mismatch the clock is left alone; the sequencer
+                // will fail the sequence itself when it compares the times.
                 const Fw::Time& wakeup = seq.m_runtime.wakeupTime;
-                if (wakeup.getTimeBase() == this->m_now.getTimeBase() && this->m_now < wakeup) {
-                    this->m_now = wakeup;
+                if (wakeup.getTimeBase() == this->m_now.getTimeBase()) {
+                    if (this->m_now < wakeup) {
+                        this->m_now = wakeup;
+                    } else {
+                        this->m_now.add(0, CHECK_TIMERS_PERIOD_USEC);
+                    }
                 }
                 this->schedSend_out(0, 0);
                 continue;

--- a/test/harness/FpySequencerTester.hpp
+++ b/test/harness/FpySequencerTester.hpp
@@ -35,6 +35,9 @@ class FpySequencerTester : public FpySequencerTesterComponentBase {
     // real time because the clock jumps instead of waiting.
     static constexpr U32 MAX_DISPATCHES = 1000 * 1000;
     static constexpr FwSizeType QUEUE_DEPTH = 32;
+    // Simulated period of the checkTimers port: how far the clock advances
+    // when the sequencer sleeps until a time that has already come.
+    static constexpr U32 CHECK_TIMERS_PERIOD_USEC = 100 * 1000;
 
     void connectPorts();
     // Sends the RUN (or RUN_ARGS) command that starts the sequence.

--- a/test/harness/wasm/tester/WasmSequencerTester.cpp
+++ b/test/harness/wasm/tester/WasmSequencerTester.cpp
@@ -130,12 +130,18 @@ void WasmSequencerTester::pump() {
             if (state == WasmState::RUNNING_AWAITING_RESPONSE_SLEEPING && seq.m_hasPendingTimer) {
                 // The sequence is sleeping. Jump the clock to the wake-up
                 // time instead of waiting, then let the sequencer check its
-                // timers. On a time base mismatch the clock is left alone;
-                // the sequencer fails the sequence itself when it compares
-                // the times.
+                // timers. A wake-up time that has already come (a
+                // zero-duration sleep) resumes on the next checkTimers call,
+                // one CHECK_TIMERS_PERIOD_USEC later. On a time base mismatch
+                // the clock is left alone; the sequencer fails the sequence
+                // itself when it compares the times.
                 const Fw::Time& wakeup = seq.m_pendingTimer;
-                if (wakeup.getTimeBase() == this->m_now.getTimeBase() && this->m_now < wakeup) {
-                    this->m_now = wakeup;
+                if (wakeup.getTimeBase() == this->m_now.getTimeBase()) {
+                    if (this->m_now < wakeup) {
+                        this->m_now = wakeup;
+                    } else {
+                        this->m_now.add(0, CHECK_TIMERS_PERIOD_USEC);
+                    }
                 }
                 this->schedSend_out(0, 0);
                 continue;

--- a/test/harness/wasm/tester/WasmSequencerTester.hpp
+++ b/test/harness/wasm/tester/WasmSequencerTester.hpp
@@ -33,6 +33,9 @@ class WasmSequencerTester : public WasmSequencerTesterComponentBase {
     // INSTRUCTION_FUEL (default 1000) wasm instructions.
     static constexpr U32 MAX_DISPATCHES = 1000 * 1000;
     static constexpr FwSizeType QUEUE_DEPTH = 32;
+    // Simulated period of the checkTimers port: how far the clock advances
+    // when the sequencer sleeps until a time that has already come.
+    static constexpr U32 CHECK_TIMERS_PERIOD_USEC = 100 * 1000;
 
     void connectPorts();
     // Sends the RUN command that loads and runs the module.


### PR DESCRIPTION
* Make the default period for the check statement 0 seconds, so it will check at the rate of the `checkTimers` port