### PR TITLE
Require compile-time constant arguments to time()

### DIFF
--- a/src/fpy/macros.py
+++ b/src/fpy/macros.py
@@ -369,6 +369,9 @@ TIME_MACRO = BuiltinFuncSymbol(
         ("timeContext", U8, FpyValue(U8, 0)),
     ],
     lambda n, c, t: [],  # placeholder - const eval handles this
+    # every argument must be a compile-time constant: time() is always
+    # evaluated at compile time and has no runtime lowering
+    const_arg_indices=frozenset({0, 1, 2}),
 )
 
 MACROS: dict[str, BuiltinFuncSymbol] = {

--- a/test/fpy/test_time_seqs.py
+++ b/test/fpy/test_time_seqs.py
@@ -1250,3 +1250,25 @@ t: Fw.Time = time("1969-01-01T00:00:00Z")
 t: Fw.Time = time("2200-01-01T00:00:00Z")
 """
         assert_compile_failure(fprime_test_api, seq)
+
+    def test_time_function_runtime_time_base(self, fprime_test_api):
+        """time() is evaluated at compile time, so a timeBase that is only
+        known at run time is rejected."""
+        seq = """
+b: TimeBase = TimeBase.TB_NONE
+t: Fw.Time = time("2025-01-01T00:00:00Z", b)
+"""
+        assert_compile_failure(
+            fprime_test_api, seq, match="must be a compile-time constant"
+        )
+
+    def test_time_function_runtime_time_context(self, fprime_test_api):
+        """time() is evaluated at compile time, so a timeContext that is only
+        known at run time is rejected."""
+        seq = """
+x: U8 = 1
+t: Fw.Time = time("2025-01-01T00:00:00Z", TimeBase.TB_NONE, x)
+"""
+        assert_compile_failure(
+            fprime_test_api, seq, match="must be a compile-time constant"
+        )


### PR DESCRIPTION
* Force all arguments to the time() builtin to be constants