### PR TITLE
Give each runtime index in an element store its own bounds-check label

### DIFF
--- a/src/fpy/codegen_fpybc.py
+++ b/src/fpy/codegen_fpybc.py
@@ -1203,8 +1203,13 @@ class GenerateFunctionBody(EmitterWithNodeInfo):
             # Emit code to compute each dynamic offset component
             # (idx * elem_size) and sum them together on the stack.
             for i, (idx_expr, parent_type) in enumerate(dynamic_components):
+                # the bounds check's label is named after the node it is
+                # given; the index expression is unique per component, the
+                # assignment is not
                 dirs.extend(
-                    self._emit_array_element_offset(node, idx_expr, parent_type, state)
+                    self._emit_array_element_offset(
+                        idx_expr, idx_expr, parent_type, state
+                    )
                 )
                 if i > 0:
                     dirs.append(IntAddDirective())

--- a/test/fpy/test_types_and_constructors.py
+++ b/test/fpy/test_types_and_constructors.py
@@ -404,6 +404,40 @@ assert pick(1) == 20
 """
         assert_run_success(fprime_test_api, seq)
 
+    def test_assign_array_element_two_runtime_indices(self, fprime_test_api):
+        """A store whose access chain has two runtime indices: each index
+        needs its own bounds check."""
+        seq = """
+a: Ref.TooManyChoices = Ref.TooManyChoices( \\
+    Ref.ManyChoices(Ref.Choice.ONE, Ref.Choice.ONE), \\
+    Ref.ManyChoices(Ref.Choice.ONE, Ref.Choice.ONE))
+i: I64 = 1
+j: I64 = 0
+a[i][j] = Ref.Choice.TWO
+assert a[1][0] == Ref.Choice.TWO
+assert a[1][1] == Ref.Choice.ONE
+assert a[0][0] == Ref.Choice.ONE
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_assign_global_array_element_two_runtime_indices_in_function(
+        self, fprime_test_api
+    ):
+        """The same two-runtime-index store, from a function writing a global."""
+        seq = """
+g: Ref.TooManyChoices = Ref.TooManyChoices( \\
+    Ref.ManyChoices(Ref.Choice.ONE, Ref.Choice.ONE), \\
+    Ref.ManyChoices(Ref.Choice.ONE, Ref.Choice.ONE))
+
+def set_choice(i: I64, j: I64, c: Ref.Choice):
+    g[i][j] = c
+
+set_choice(0, 1, Ref.Choice.RED)
+assert g[0][1] == Ref.Choice.RED
+assert g[0][0] == Ref.Choice.ONE
+"""
+        assert_run_success(fprime_test_api, seq)
+
 
 class TestConstFoldEquality:
 


### PR DESCRIPTION
* Label name for a goto label in the array OOB check in fpybc was not unique when two or more runtime indices were used on an array
* This pr names the label by the index expr