### PR TITLE
Reject constant floats that overflow to infinity

### DIFF
--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 import decimal
 import itertools
+import math
 from pathlib import Path
 import struct
 from typing import Union
@@ -2356,7 +2357,10 @@ class CalculateConstExprValues(Visitor):
                 rounded_value = CalculateConstExprValues._round_float_to_type(
                     coerced_value, to_type
                 )
-                if rounded_value is None:
+                # a value too large for the type either fails to pack or, past
+                # the double range, silently becomes infinite; there is no
+                # literal for an infinite value, so both are out of range
+                if rounded_value is None or not math.isfinite(rounded_value):
                     state.err(
                         f"{raw_val} is out of range for type {to_type.display_name}",
                         node,

--- a/test/fpy/test_types_and_constructors.py
+++ b/test/fpy/test_types_and_constructors.py
@@ -571,6 +571,31 @@ x()
         assert_compile_failure(fprime_test_api, seq)
 
 
+class TestNonFiniteFloatConstants:
+    """A constant float that does not fit its finite float type is a compile
+    error, never a silent infinity."""
+
+    def test_f64_literal_overflow(self, fprime_test_api):
+        seq = "x: F64 = 1e999\n"
+        assert_compile_failure(fprime_test_api, seq, match="out of range for type F64")
+
+    def test_f32_literal_overflow(self, fprime_test_api):
+        seq = "x: F32 = 1e999\n"
+        assert_compile_failure(fprime_test_api, seq, match="out of range for type F32")
+
+    def test_f64_folded_overflow(self, fprime_test_api):
+        seq = "x: F64 = 1e308 * 10.0\n"
+        assert_compile_failure(fprime_test_api, seq, match="out of range for type F64")
+
+    def test_f64_folded_overflow_of_typed_operands(self, fprime_test_api):
+        seq = "x: F64 = F64(1e308) * F64(10.0)\n"
+        assert_compile_failure(fprime_test_api, seq, match="out of range for type F64")
+
+    def test_f64_max_is_in_range(self, fprime_test_api):
+        seq = "x: F64 = 1.7976931348623157e308\nassert x > 1e308\n"
+        assert_run_success(fprime_test_api, seq)
+
+
 class TestStringTypes:
 
     def test_string_eq(self, fprime_test_api):


### PR DESCRIPTION
If we can't fit a floating point constant into a F32 or F64, an error should be raised, it shouldn't silently turn into an inf