### PR TITLE
Fold non-numeric equality by serialized bytes to match the runtime

### DIFF
--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -2672,6 +2672,18 @@ class CalculateConstExprValues(Visitor):
 
         state.const_expr_values[node] = expr_value
 
+    @staticmethod
+    def _const_equal(lhs: FpyValue, rhs: FpyValue) -> bool:
+        """== of two constants. Numbers compare by value; a non-numeric operand
+        (struct, array, enum, time) compares by serialized bytes, which is
+        what the runtime compares (spec "Equality semantics"), so that folding
+        cannot change a comparison's answer: 0.0 and -0.0 are equal as
+        numbers but not as struct members."""
+        if lhs.type.is_numerical:
+            return lhs.val == rhs.val
+        assert lhs.type == rhs.type, (lhs.type, rhs.type)
+        return lhs.serialize() == rhs.serialize()
+
     def visit_AstBinaryOp(self, node: AstBinaryOp, state: CompileState):
         # Check if both left-hand side (lhs) and right-hand side (rhs) are constants
         lhs_value: FpyValue = state.const_expr_values.get(node.lhs)
@@ -2689,6 +2701,8 @@ class CalculateConstExprValues(Visitor):
             return
 
         # Both sides are constants, evaluate the operation if the operator is supported
+        lhs_const = lhs_value
+        rhs_const = rhs_value
         # get the actual pythonic value from the fpy type
         lhs_value = lhs_value.val
         rhs_value = rhs_value.val
@@ -2736,9 +2750,9 @@ class CalculateConstExprValues(Visitor):
                 folded_value = lhs_value <= rhs_value
             # Equality Checking
             elif node.op == BinaryStackOp.EQUAL:
-                folded_value = lhs_value == rhs_value
+                folded_value = self._const_equal(lhs_const, rhs_const)
             elif node.op == BinaryStackOp.NOT_EQUAL:
-                folded_value = lhs_value != rhs_value
+                folded_value = not self._const_equal(lhs_const, rhs_const)
             else:
                 # missing an operation
                 assert False, node.op

--- a/test/fpy/test_types_and_constructors.py
+++ b/test/fpy/test_types_and_constructors.py
@@ -473,6 +473,44 @@ exit(1)
 
         assert_run_success(fprime_test_api, seq)
 
+    def test_const_fold_struct_eq_negative_zero_member(self, fprime_test_api):
+        """Folded aggregate equality compares serialized bytes like the
+        runtime does, so a 0.0 member and a -0.0 member are not equal."""
+        seq = """
+if Ref.SignalPair(1.0, 0.0) == Ref.SignalPair(1.0, -0.0):
+    exit(1)
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_const_fold_struct_neq_negative_zero_member(self, fprime_test_api):
+        seq = """
+if Ref.SignalPair(1.0, 0.0) != Ref.SignalPair(1.0, -0.0):
+    exit(0)
+exit(1)
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_const_fold_array_eq_agrees_with_runtime(self, fprime_test_api):
+        """The folded and the runtime answers to the same comparison agree."""
+        seq = """
+a: Ref.SignalSet = Ref.SignalSet(1.0, 2.0, 3.0, 0.0)
+b: Ref.SignalSet = Ref.SignalSet(1.0, 2.0, 3.0, -0.0)
+if a == b:
+    exit(2)
+if Ref.SignalSet(1.0, 2.0, 3.0, 0.0) == Ref.SignalSet(1.0, 2.0, 3.0, -0.0):
+    exit(1)
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_const_fold_numeric_negative_zero_is_equal(self, fprime_test_api):
+        """Numbers, including aggregate members read out, still compare
+        numerically: 0.0 == -0.0."""
+        seq = """
+assert 0.0 == -0.0
+assert Ref.SignalPair(1.0, 0.0).value == Ref.SignalPair(1.0, -0.0).value
+"""
+        assert_run_success(fprime_test_api, seq)
+
     def test_runtime_array_equality(self, fprime_test_api):
         """Array equality with runtime (non-const) operands."""
         seq = """


### PR DESCRIPTION
* At runtime, non numeric equality is by serialized bytes. This PR makes it that way at const folding time too