### PR TITLE
Reserve the float libcall names on the wasm backend

### DIFF
--- a/src/fpy/wasm_host.py
+++ b/src/fpy/wasm_host.py
@@ -55,15 +55,31 @@ def _declare_host_func(
     return fn
 
 
+def _declare_libcalls(module: ir.Module) -> None:
+    """Claim the names of the float libcalls LLVM emits for llvm.pow, llvm.log
+    and frem, before any script symbol is named. Script functions and
+    variables are emitted under their own names, uniqued against the module
+    (``get_unique_name``), so without these declarations a script function or
+    variable named ``pow`` would be the symbol the libcall binds to."""
+    from llvmlite import ir
+
+    f64 = ir.DoubleType()
+    ir.Function(module, ir.FunctionType(f64, [f64, f64]), name="pow")
+    ir.Function(module, ir.FunctionType(f64, [f64]), name="log")
+    ir.Function(module, ir.FunctionType(f64, [f64, f64]), name="fmod")
+
+
 def declare_host_imports(module: ir.Module) -> None:
     """Declare the full expected host interface on *module*; emit sites look
-    the functions up in ``module.globals``. The float libcalls
-    (env.pow/fmod/log) are deliberately absent: LLVM materializes those itself
-    when lowering llvm.pow/llvm.log/frem, and they stay under wasm-ld's
-    default import module "env"."""
+    the functions up in ``module.globals``. Also declares the float libcalls
+    (env.pow/fmod/log) that LLVM materializes itself when lowering
+    llvm.pow/llvm.log/frem, only so that their names are taken: those stay
+    under wasm-ld's default import module "env" and no emit site calls
+    them."""
     from llvmlite import ir
 
     error_code_type = ErrorCodeType.llvm_type
+    _declare_libcalls(module)
 
     # exit(code) ends the whole sequence. It never returns to wasm (the host
     # unwinds the interpreter); noreturn lets LLVM drop the dead code after it.

--- a/test/fpy/test_functions.py
+++ b/test/fpy/test_functions.py
@@ -313,6 +313,55 @@ val: U32 = noop()
 """
         assert_compile_failure(fprime_test_api, seq)
 
+    def test_function_named_pow_does_not_replace_exponent(self, fprime_test_api):
+        """A script function may be named after a float libcall (pow, fmod)
+        without becoming the implementation of the operator that libcall
+        backs."""
+        seq = """
+def pow(a: F64, b: F64) -> F64:
+    return 77.0
+
+y: F64 = 2.0
+z: F64 = y ** 3.0
+assert z == 8.0
+assert pow(1.0, 1.0) == 77.0
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_function_named_fmod_does_not_replace_modulus(self, fprime_test_api):
+        seq = """
+def fmod(a: F64, b: F64) -> F64:
+    return 77.0
+
+y: F64 = 7.5
+r: F64 = y % 2.0
+assert r == 1.5
+assert fmod(1.0, 1.0) == 77.0
+"""
+        assert_run_success(fprime_test_api, seq)
+
+    def test_function_named_log_does_not_replace_ln(self, fprime_test_api):
+        seq = """
+def log(x: F64) -> F64:
+    return 77.0
+
+y: F64 = 4.0
+l: F64 = ln(y)
+assert l > 1.386 and l < 1.387
+assert log(1.0) == 77.0
+"""
+        assert_run_success(
+            fprime_test_api, seq, expected_warnings={WarningType.SHADOW_CALLABLE}
+        )
+
+    def test_variable_named_pow_does_not_break_exponent(self, fprime_test_api):
+        seq = """
+pow: F64 = 2.0
+z: F64 = pow ** 2.0
+assert z == 4.0
+"""
+        assert_run_success(fprime_test_api, seq)
+
     def test_call_embedded_in_bare_expression(self, fprime_test_api):
         """A bare expression statement whose top-level node isn't itself
         side-effecting (an == comparison) still embeds a call that is; the


### PR DESCRIPTION
* Previously, some math funcs which are implemented as env host funcs on wasm would only get a name when they were visited in the tree, so if a func which had the same name was visited first, the math func would call that other func instead of the right host func.
* Now we just reserve the names up front