### PR TITLE
Take time()'s microseconds from the parsed timestamp (#222)

### DIFF
--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -2270,9 +2270,11 @@ class CalculateConstExprValues(Visitor):
             dt = dt.replace(tzinfo=timezone.utc)
             timestamp = dt.timestamp()
 
-            # Split into seconds and microseconds
+            # Split into seconds and microseconds. The microseconds come
+            # from the parsed value, not from the float timestamp, whose
+            # resolution is coarser than a microsecond at modern dates.
             seconds = int(timestamp)
-            useconds = int((timestamp - seconds) * 1_000_000)
+            useconds = dt.microsecond
 
             # Validate ranges for U32
             if seconds < 0:

--- a/test/fpy/test_time_seqs.py
+++ b/test/fpy/test_time_seqs.py
@@ -1159,6 +1159,17 @@ assert t.useconds == 123456
 """
         assert_run_success(fprime_test_api, seq)
 
+    def test_time_function_microseconds_exact(self, fprime_test_api):
+        """The microsecond field is exact, not one low from a float
+        subtraction that loses resolution at modern timestamps."""
+        seq = """
+t: Fw.Time = time("2025-12-19T14:30:00.000007Z")
+assert t.useconds == 7
+u: Fw.Time = time("2026-09-08T00:00:00.000001Z")
+assert u.useconds == 1
+"""
+        assert_run_success(fprime_test_api, seq)
+
     def test_time_function_sleep_until(self, fprime_test_api):
         """time() can be passed directly to sleep_until()."""
         seq = """


### PR DESCRIPTION
Fixes #222.

`_parse_time_string` derived the microsecond field from the float timestamp
(`int((dt.timestamp() - seconds) * 1_000_000)`). A double only resolves about
2e-7 s at a 2025 date, so the product often lands just below the integer and
truncates one low: `time("2025-12-19T14:30:00.000007Z").useconds` was 6.
`dt.microsecond` is the exact value the string was parsed into.

Red/green: the new sequence test asserts `useconds == 7` and `useconds == 1`
for two timestamps that truncate low today; it exits nonzero on both backends
before the one-line change and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)