### PR TITLE
Report a diagnostic when a non-finite float constant is cast to an integer (#229)

### DIFF
--- a/src/fpy/semantics.py
+++ b/src/fpy/semantics.py
@@ -2421,7 +2421,8 @@ class CalculateConstExprValues(Visitor):
                 return FpyValue(to_type, raw_val)
 
             assert False, (from_val, from_type, to_type)
-        except (ValueError, struct.error) as e:
+        except (ValueError, OverflowError, struct.error) as e:
+            # OverflowError is int(inf); ValueError is int(nan)
             state.err(f"For type {from_type.display_name}: {e}", node)
             return None
 

--- a/test/fpy/test_arithmetic.py
+++ b/test/fpy/test_arithmetic.py
@@ -56,6 +56,34 @@ exit(1)
 
         assert_compile_failure(fprime_test_api, seq)
 
+    def test_const_infinity_to_int(self, fprime_test_api):
+        """An infinite float constant cast to an integer type is a compile
+        error, not an uncaught OverflowError."""
+        seq = """
+x: I64 = I64(F64(1e308) * F64(10.0))
+exit(0)
+"""
+
+        assert_compile_failure(fprime_test_api, seq, match="infinity")
+
+    def test_const_negative_infinity_to_int(self, fprime_test_api):
+        """The same holds for a negative infinity and an unsigned target."""
+        seq = """
+x: U8 = U8(F64(-1e308) + F64(-1e308))
+exit(0)
+"""
+
+        assert_compile_failure(fprime_test_api, seq, match="infinity")
+
+    def test_const_nan_to_int(self, fprime_test_api):
+        """The NaN counterpart reports a diagnostic too."""
+        seq = """
+x: I64 = I64(F64(1e308) * F64(10.0) - F64(1e308) * F64(10.0))
+exit(0)
+"""
+
+        assert_compile_failure(fprime_test_api, seq, match="NaN")
+
     def test_very_large_const_pow(self, fprime_test_api):
         seq = """
 10.0 ** 1000


### PR DESCRIPTION
Fixes #229.

`const_convert_type` caught the `ValueError` that `int()` raises for NaN but
not the `OverflowError` it raises for infinity, so casting an infinite constant
to any integer type escaped as an uncaught Python exception in every position
that coerces the cast (assignments, command arguments, array indices, range
bounds, `exit` and `assert` codes). Listing `OverflowError` alongside
`ValueError` gives it the same diagnostic the NaN case already gets:
`For type F64: cannot convert float infinity to integer`.

Red/green: the two infinity sequences crash with `OverflowError: cannot convert
float infinity to integer` before the change and report a compile error after;
the NaN sequence guards the branch that already worked. They reach infinity by
overflowing a float multiply/add rather than through an out-of-range literal, so
they stay valid independently of #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)