### PR TITLE
Validate Fw.LogSeverity against the dictionary like the other canonical types (#225)

### DIFF
--- a/src/fpy/state.py
+++ b/src/fpy/state.py
@@ -588,6 +588,12 @@ def _build_global_scopes(
         dict_type_name_dict, "Fw.TimeComparison", TIME_COMPARISON
     )
     _validate_and_replace_type(dict_type_name_dict, "Svc.BlockState", BLOCK_STATE)
+    # Fw.LogSeverity backs log()'s severity argument. A dictionary without
+    # events never defines it, so it is optional -- but when a dictionary does
+    # define it, its representation must match the one log() pushes.
+    _validate_and_replace_type(
+        dict_type_name_dict, "Fw.LogSeverity", LOG_SEVERITY, required=False
+    )
     _update_seq_args_from_dict(dict_type_name_dict)
 
     # Build the full type dict: start from (now-validated) dictionary types,

--- a/test/fpy/test_compiler_config.py
+++ b/test/fpy/test_compiler_config.py
@@ -857,3 +857,70 @@ def test_param_valid_absent_is_tolerated():
     finally:
         Path(dict_path).unlink()
         _clear_caches()
+
+
+# ============================================================================
+# Fw.LogSeverity validation
+# ============================================================================
+
+
+def test_log_severity_mismatch_raises_error():
+    """A dictionary whose Fw.LogSeverity disagrees with the canonical enum is
+    rejected: log() pushes a severity of the canonical representation type,
+    and the runtime pops it as Fw::LogSeverity::SerialType."""
+    _clear_caches()
+
+    def widen_rep(type_def):
+        type_def["representationType"] = {
+            "name": "U16",
+            "kind": "integer",
+            "size": 16,
+            "signed": False,
+        }
+
+    dict_path = _create_test_dict_with_modified_type("Fw.LogSeverity", widen_rep)
+
+    try:
+        from fpy.error import DictionaryError
+
+        with pytest.raises(DictionaryError, match="Fw.LogSeverity"):
+            get_base_compile_state(dict_path)
+    finally:
+        Path(dict_path).unlink()
+        _clear_caches()
+
+
+def test_log_severity_constant_mismatch_raises_error():
+    """Renumbering one of its constants is rejected too."""
+    _clear_caches()
+
+    def renumber(type_def):
+        for const in type_def["enumeratedConstants"]:
+            if const["name"] == "FATAL":
+                const["value"] = 9
+
+    dict_path = _create_test_dict_with_modified_type("Fw.LogSeverity", renumber)
+
+    try:
+        from fpy.error import DictionaryError
+
+        with pytest.raises(DictionaryError, match="Fw.LogSeverity"):
+            get_base_compile_state(dict_path)
+    finally:
+        Path(dict_path).unlink()
+        _clear_caches()
+
+
+def test_log_severity_absent_is_tolerated():
+    """A dictionary that never mentions it leaves the canonical definition
+    standing."""
+    _clear_caches()
+
+    dict_path = _create_test_dict_with_modified_type("Fw.LogSeverity", None)
+
+    try:
+        state = get_base_compile_state(dict_path)
+        assert state is not None
+    finally:
+        Path(dict_path).unlink()
+        _clear_caches()


### PR DESCRIPTION
Fixes #225.

Every other canonical type the compiler bakes in (`Fw.CmdResponse`,
`Fw.TimeComparison`, `Svc.BlockState`, ...) goes through
`_validate_and_replace_type`, but `LOG_SEVERITY` was layered over the
dictionary's definition unchecked. A dictionary defining `Fw.LogSeverity` with
another representation type would have `log()` push a one-byte severity while
`POP_EVENT` pops `Fw::LogSeverity::SerialType`, silently misreading the stack.
It is registered `required=False`, like the validity enums, so a dictionary
without events still loads.

Red/green: the two new dictionaries (one widening the representation type to
U16, one renumbering `FATAL`) load without complaint before the change and
raise `DictionaryError` after; the third checks that removing the type
altogether still leaves the canonical definition standing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)