### PR TITLE
Report a backend error naming the builtin instead of raising NotImplementedError on wasm

### DIFF
--- a/src/fpy/codegen_llvm.py
+++ b/src/fpy/codegen_llvm.py
@@ -337,7 +337,7 @@ class EmitLlvmExpr(Emitter):
             ]
             return self._emit_command_dispatch(command, values)
         elif is_instance_compat(func, BuiltinFuncSymbol):
-            return self._emit_builtin_call(node_args, func, state)
+            return self._emit_builtin_call(node, node_args, func, state)
         elif is_instance_compat(func, TypeCtorSymbol):
             # A ctor call with all-constant args folds before reaching here;
             # what remains builds the aggregate (struct or array) from its
@@ -369,8 +369,17 @@ class EmitLlvmExpr(Emitter):
             assert False, func
 
     def _emit_builtin_call(
-        self, node_args: list, func: BuiltinFuncSymbol, state: CompileState
+        self,
+        node: AstFuncCall,
+        node_args: list,
+        func: BuiltinFuncSymbol,
+        state: CompileState,
     ) -> ir.Value | None:
+        if func.generate_llvm is None:
+            raise BackendError(
+                f"the '{func.name}' builtin is not supported by the wasm backend",
+                node,
+            )
         # Pass each argument as (emitted ir.Value, its constant FpyValue or
         # None if it isn't a compile-time constant, its contextual type). The
         # builtin's generate_llvm picks whichever it needs. Args the builtin

--- a/src/fpy/symbols.py
+++ b/src/fpy/symbols.py
@@ -24,12 +24,6 @@ class CommandSymbol(CallableSymbol):
     is_seq_run_with_args: bool = False
 
 
-def _generate_llvm_unsupported(builder, args):
-    """Default LLVM lowering: a builtin that hasn't been taught the llvm/wasm
-    backend yet. Raises rather than silently miscompiling."""
-    raise NotImplementedError("this builtin has no LLVM/wasm lowering yet")
-
-
 @dataclass
 class BuiltinFuncSymbol(CallableSymbol):
     generate_fpybc: Callable[
@@ -39,7 +33,7 @@ class BuiltinFuncSymbol(CallableSymbol):
     dict mapping const_arg_indices to their compile-time values, and the
     contextual (coerced) type of each argument in positional order. Non-const
     args are already pushed on the stack by the caller."""
-    generate_llvm: Callable = _generate_llvm_unsupported
+    generate_llvm: Callable | None = None
     """llvm/wasm backend: builds the call's LLVM IR. Called as
     generate_llvm(builder, args), where args is a list of (ir.Value or None,
     FpyValue or None, FpyType) triples -- each argument's emitted value,
@@ -47,7 +41,8 @@ class BuiltinFuncSymbol(CallableSymbol):
     contextual (coerced) type. Args in const_arg_indices, and args whose type
     has no machine representation (a string), are never emitted and arrive as
     (None, value, type). Returns the result ir.Value (or None for a
-    NOTHING-typed builtin). Defaults to raising 'not lowered yet'."""
+    NOTHING-typed builtin). None when the builtin has no llvm/wasm lowering,
+    which the backend reports as an error at the call."""
     const_arg_indices: frozenset[int] = field(default_factory=frozenset)
     """indices of args that must be compile-time constants and are NOT pushed
     to the stack; instead their values are passed to generate_fpybc()"""

--- a/test/fpy/test_wasm.py
+++ b/test/fpy/test_wasm.py
@@ -37,6 +37,7 @@ from fpy.wasm_host import (
 )
 from fpy.compiler import analyze_ast, text_to_ast
 from fpy.dictionary import load_dictionary
+from fpy.error import BackendError
 from fpy.bytecode.directives import DirectiveErrorCode
 from fpy.state import get_base_compile_state
 from fpy.test_helpers import (
@@ -132,6 +133,20 @@ class TestWasmLowering:
         seq = "x: F64 = 1e20\ny: I32 = I32(x)\nassert y == 0\n"
         assert "i32.trunc_sat_f64_s" not in _emit_wasm_asm(seq, cpu=LLVM_CPU)
         assert "i32.trunc_sat_f64_s" in _emit_wasm_asm(seq, cpu="generic")
+
+    @pytest.mark.parametrize(
+        "seq",
+        [
+            "x: U32 = rand()\n",
+            "x: F64 = randf()\n",
+            "set_seed(1)\n",
+        ],
+    )
+    def test_builtin_without_lowering_is_a_backend_error(self, seq):
+        # The rng builtins have no llvm/wasm lowering. Using one must be a
+        # BackendError naming the builtin, not an exception escaping codegen.
+        with pytest.raises(BackendError, match="not supported by the wasm backend"):
+            _seq_to_llvm_module(seq)
 
 
 class TestWasmHostImports:


### PR DESCRIPTION
`rand()`, `randf()` and `set_seed()` have no llvm/wasm lowering, and the placeholder `generate_llvm` raised `NotImplementedError` — which is neither a `CompileError` nor a `BackendError`, so `compile_main` didn't catch it and the user got a traceback:

```
$ fprime-fpyc rnd.fpy -d TopologyDictionary.json --emit wasm
...
NotImplementedError: this builtin has no LLVM/wasm lowering yet
```

`generate_llvm` now defaults to `None` and the backend raises a `BackendError` at the call, so it points at the source like every other backend error:

```
rnd.fpy:1 the 'rand' builtin is not supported by the wasm backend
     1 | x: U32 = rand()
                  ^^^^^^
```

It is still a hard error — nothing is silently miscompiled.
